### PR TITLE
feat: デザイン設定パネルの実装 (透かし・QR) #10

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,18 @@
 import { useState } from 'react'
+import { useShallow } from 'zustand/shallow'
 import type { View } from './types'
 import ContactList from './components/address/ContactList'
 import PreviewArea from './components/preview/PreviewArea'
+import DecorationSidebar from './components/decoration/DecorationSidebar'
+import { useDecorationStore } from './stores/decorationStore'
 
 function App() {
   const [view, setView] = useState<View>('contacts')
+  const { showDecoPanel, toggleDecoPanel } = useDecorationStore(
+    useShallow((s) => ({ showDecoPanel: s.showDecoPanel, toggleDecoPanel: s.toggleDecoPanel })),
+  )
+
+  const showPreview = view === 'contacts' || view === 'preview'
 
   return (
     <div className="flex h-screen bg-gray-50 text-gray-900">
@@ -29,8 +37,27 @@ function App() {
             <ContactList />
           </div>
         )}
-        {view === 'contacts' && <PreviewArea />}
-        {view === 'preview' && <PreviewArea />}
+        {showPreview && (
+          <>
+            <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+              {/* トップバー */}
+              <div className="flex items-center justify-end px-4 py-2 bg-white border-b border-gray-200 shrink-0">
+                <button
+                  onClick={toggleDecoPanel}
+                  className={`px-3 py-1.5 text-xs rounded border transition-colors ${
+                    showDecoPanel
+                      ? 'bg-blue-50 border-blue-400 text-blue-700'
+                      : 'border-gray-300 text-gray-600 hover:bg-gray-100'
+                  }`}
+                >
+                  デザイン設定
+                </button>
+              </div>
+              <PreviewArea />
+            </div>
+            {showDecoPanel && <DecorationSidebar />}
+          </>
+        )}
         {view === 'settings' && (
           <div className="flex-1 p-6">
             <h2 className="text-xl font-semibold mb-4">設定</h2>

--- a/frontend/src/components/decoration/DecorationSidebar.tsx
+++ b/frontend/src/components/decoration/DecorationSidebar.tsx
@@ -1,0 +1,17 @@
+import WatermarkPanel from './WatermarkPanel'
+import QRPanel from './QRPanel'
+
+export default function DecorationSidebar() {
+  return (
+    <div className="w-60 bg-white border-l border-gray-200 flex flex-col h-full shrink-0">
+      <div className="px-4 py-3 border-b border-gray-200">
+        <h2 className="text-sm font-semibold text-gray-700">デザイン設定</h2>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 space-y-6">
+        <WatermarkPanel />
+        <div className="border-t border-gray-100" />
+        <QRPanel />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/decoration/QRPanel.tsx
+++ b/frontend/src/components/decoration/QRPanel.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from 'react'
+import QRCode from 'qrcode'
+import { useShallow } from 'zustand/shallow'
+import { useDecorationStore } from '../../stores/decorationStore'
+import type { QRConfig } from '../../types'
+
+const POSITIONS: { id: QRConfig['position']; label: string }[] = [
+  { id: 'top-left', label: '左上' },
+  { id: 'top-right', label: '右上' },
+  { id: 'bottom-left', label: '左下' },
+  { id: 'bottom-right', label: '右下' },
+]
+
+export default function QRPanel() {
+  const { qrConfig, setQRConfig } = useDecorationStore(
+    useShallow((s) => ({ qrConfig: s.qrConfig, setQRConfig: s.setQRConfig })),
+  )
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !qrConfig.enabled || !qrConfig.content) return
+    QRCode.toCanvas(canvas, qrConfig.content, { width: 80, margin: 1 }).catch(() => {})
+  }, [qrConfig.enabled, qrConfig.content])
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+        QRコード
+      </h3>
+
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm text-gray-700">QRコードを表示</span>
+        <button
+          onClick={() => setQRConfig({ enabled: !qrConfig.enabled })}
+          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+            qrConfig.enabled ? 'bg-blue-500' : 'bg-gray-300'
+          }`}
+          aria-label="QRコードON/OFF"
+        >
+          <span
+            className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
+              qrConfig.enabled ? 'translate-x-5' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
+
+      {qrConfig.enabled && (
+        <>
+          <div className="mb-3">
+            <label className="block text-xs text-gray-500 mb-1">URLまたはテキスト</label>
+            <input
+              type="text"
+              value={qrConfig.content}
+              onChange={(e) => setQRConfig({ content: e.target.value })}
+              placeholder="https://example.com"
+              className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded focus:outline-none focus:border-blue-400"
+            />
+          </div>
+
+          <div className="mb-3">
+            <label className="block text-xs text-gray-500 mb-1">配置</label>
+            <div className="grid grid-cols-2 gap-1">
+              {POSITIONS.map((pos) => (
+                <button
+                  key={pos.id}
+                  onClick={() => setQRConfig({ position: pos.id })}
+                  className={`py-1 text-xs rounded border transition-colors ${
+                    qrConfig.position === pos.id
+                      ? 'border-blue-500 bg-blue-50 text-blue-700'
+                      : 'border-gray-200 hover:border-gray-300'
+                  }`}
+                >
+                  {pos.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {qrConfig.content && (
+            <div className="flex justify-center">
+              <canvas ref={canvasRef} className="border border-gray-200 rounded" />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/decoration/WatermarkPanel.tsx
+++ b/frontend/src/components/decoration/WatermarkPanel.tsx
@@ -1,0 +1,107 @@
+import { useShallow } from 'zustand/shallow'
+import { useDecorationStore } from '../../stores/decorationStore'
+
+const PRESETS = [
+  { id: 'none', label: 'なし', emoji: '✕' },
+  { id: 'sakura', label: '桜', emoji: '🌸' },
+  { id: 'wave', label: '波', emoji: '🌊' },
+  { id: 'bamboo', label: '竹', emoji: '🎋' },
+  { id: 'fuji', label: '富士山', emoji: '🗻' },
+  { id: 'crane', label: '鶴', emoji: '🦢' },
+  { id: 'custom', label: 'カスタム', emoji: '📷' },
+]
+
+export default function WatermarkPanel() {
+  const { watermark, setWatermark } = useDecorationStore(
+    useShallow((s) => ({ watermark: s.watermark, setWatermark: s.setWatermark })),
+  )
+
+  const currentId = watermark?.id ?? 'none'
+  const opacity = watermark?.opacity ?? 0.3
+
+  const handlePresetSelect = (id: string) => {
+    if (id === 'none') {
+      setWatermark(null)
+      return
+    }
+    if (id === 'custom') {
+      setWatermark({
+        id: 'custom',
+        name: 'カスタム',
+        type: 'custom',
+        filePath: watermark?.type === 'custom' ? watermark.filePath : '',
+        opacity,
+      })
+      return
+    }
+    const preset = PRESETS.find((p) => p.id === id)!
+    setWatermark({ id, name: preset.label, type: 'preset', filePath: '', opacity })
+  }
+
+  const handleOpacityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!watermark || watermark.id === 'none') return
+    setWatermark({ ...watermark, opacity: Number(e.target.value) / 100 })
+  }
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result as string
+      setWatermark({ id: 'custom', name: 'カスタム', type: 'custom', filePath: dataUrl, opacity })
+    }
+    reader.readAsDataURL(file)
+  }
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+        透かし画像
+      </h3>
+
+      <div className="grid grid-cols-3 gap-1 mb-3">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            onClick={() => handlePresetSelect(preset.id)}
+            className={`flex flex-col items-center justify-center p-2 rounded border text-center transition-colors ${
+              currentId === preset.id
+                ? 'border-blue-500 bg-blue-50'
+                : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+            }`}
+          >
+            <span className="text-base leading-none">{preset.emoji}</span>
+            <span className="text-[10px] mt-0.5 text-gray-600">{preset.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {watermark && watermark.id !== 'none' && (
+        <div className="mb-3">
+          <div className="flex justify-between text-xs text-gray-500 mb-1">
+            <span>透明度</span>
+            <span>{Math.round(opacity * 100)}%</span>
+          </div>
+          <input
+            type="range"
+            min="10"
+            max="100"
+            value={Math.round(opacity * 100)}
+            onChange={handleOpacityChange}
+            className="w-full accent-blue-500"
+          />
+        </div>
+      )}
+
+      {currentId === 'custom' && (
+        <label className="block cursor-pointer">
+          <div className="flex items-center justify-center w-full px-3 py-2 border border-dashed border-gray-300 rounded hover:border-blue-400 hover:bg-blue-50 transition-colors text-xs text-gray-500">
+            画像をアップロード
+          </div>
+          <input type="file" accept="image/*" className="hidden" onChange={handleFileUpload} />
+        </label>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/stores/decorationStore.test.ts
+++ b/frontend/src/stores/decorationStore.test.ts
@@ -10,7 +10,7 @@ const defaultQRConfig: QRConfig = {
 }
 
 beforeEach(() => {
-  useDecorationStore.setState({ watermark: null, qrConfig: defaultQRConfig })
+  useDecorationStore.setState({ watermark: null, qrConfig: defaultQRConfig, showDecoPanel: false })
 })
 
 describe('decorationStore', () => {
@@ -45,5 +45,13 @@ describe('decorationStore', () => {
   it('setQRConfig: positionの変更', () => {
     useDecorationStore.getState().setQRConfig({ position: 'top-left' })
     expect(useDecorationStore.getState().qrConfig.position).toBe('top-left')
+  })
+
+  it('toggleDecoPanel: ON/OFFが切り替わる', () => {
+    expect(useDecorationStore.getState().showDecoPanel).toBe(false)
+    useDecorationStore.getState().toggleDecoPanel()
+    expect(useDecorationStore.getState().showDecoPanel).toBe(true)
+    useDecorationStore.getState().toggleDecoPanel()
+    expect(useDecorationStore.getState().showDecoPanel).toBe(false)
   })
 })

--- a/frontend/src/stores/decorationStore.ts
+++ b/frontend/src/stores/decorationStore.ts
@@ -4,8 +4,10 @@ import type { Watermark, QRConfig } from '../types'
 interface DecorationState {
   watermark: Watermark | null
   qrConfig: QRConfig
+  showDecoPanel: boolean
   setWatermark: (watermark: Watermark | null) => void
   setQRConfig: (config: Partial<QRConfig>) => void
+  toggleDecoPanel: () => void
 }
 
 const defaultQRConfig: QRConfig = {
@@ -18,6 +20,8 @@ const defaultQRConfig: QRConfig = {
 export const useDecorationStore = create<DecorationState>((set, get) => ({
   watermark: null,
   qrConfig: defaultQRConfig,
+  showDecoPanel: false,
   setWatermark: (watermark) => set({ watermark }),
   setQRConfig: (config) => set({ qrConfig: { ...get().qrConfig, ...config } }),
+  toggleDecoPanel: () => set({ showDecoPanel: !get().showDecoPanel }),
 }))


### PR DESCRIPTION
## Summary

- `WatermarkPanel.tsx`: プリセット7種 (なし/桜/波/竹/富士山/鶴/カスタム)・透明度スライダー・カスタム画像アップロード
- `QRPanel.tsx`: ON/OFFトグル・URLまたはテキスト入力・配置選択 (4隅)・インラインQRプレビュー
- `DecorationSidebar.tsx`: 上記パネルを統合した右サイドバー (240px)
- `decorationStore`: `showDecoPanel` / `toggleDecoPanel` を追加
- `App.tsx`: 「デザイン設定」トグルボタンをトップバーに追加・右サイドバーを条件表示

## Test plan

- [ ] 住所録/プレビュー画面で「デザイン設定」ボタンをクリックすると右パネルが開閉する
- [ ] 透かしプリセットを選択するとプレビューに反映される
- [ ] 透明度スライダーを動かすとリアルタイムに変化する
- [ ] カスタムを選択して画像をアップロードできる
- [ ] QR ON/OFF トグルが動作する
- [ ] QR コンテンツ入力でプレビューにQRが表示される
- [ ] `vitest run` 全テスト通過 (40 tests)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * デコレーションパネルを追加しました。ウォーターマークとQRコード設定を統合管理できます。
  * ウォーターマーク機能：プリセット（桜、波、竹、富士、鶴）から選択、カスタムアップロード、不透明度調整が可能です。
  * QRコード機能：有効/無効の切り替え、コンテンツ入力、4つの位置からの配置選択ができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->