### PR TITLE
feat: 差出人管理画面の実装 #25

### DIFF
--- a/app.go
+++ b/app.go
@@ -23,12 +23,13 @@ type App struct {
 	watermarkUseCase *usecase.WatermarkUseCase
 	qrCodeUseCase    *usecase.QRCodeUseCase
 	printUseCase     *usecase.PrintUseCase
+	senderUseCase    *usecase.SenderUseCase
 	postalRepo       repository.PostalRepository
 }
 
 // NewApp creates a new App application struct
-func NewApp(contactUC *usecase.ContactUseCase, csvUC *usecase.CSVUseCase, groupUC *usecase.GroupUseCase, watermarkUC *usecase.WatermarkUseCase, qrCodeUC *usecase.QRCodeUseCase, printUC *usecase.PrintUseCase, postalRepo repository.PostalRepository) *App {
-	return &App{contactUseCase: contactUC, csvUseCase: csvUC, groupUseCase: groupUC, watermarkUseCase: watermarkUC, qrCodeUseCase: qrCodeUC, printUseCase: printUC, postalRepo: postalRepo}
+func NewApp(contactUC *usecase.ContactUseCase, csvUC *usecase.CSVUseCase, groupUC *usecase.GroupUseCase, watermarkUC *usecase.WatermarkUseCase, qrCodeUC *usecase.QRCodeUseCase, printUC *usecase.PrintUseCase, senderUC *usecase.SenderUseCase, postalRepo repository.PostalRepository) *App {
+	return &App{contactUseCase: contactUC, csvUseCase: csvUC, groupUseCase: groupUC, watermarkUseCase: watermarkUC, qrCodeUseCase: qrCodeUC, printUseCase: printUC, senderUseCase: senderUC, postalRepo: postalRepo}
 }
 
 // startup is called when the app starts. The context is saved
@@ -246,6 +247,40 @@ func (a *App) GenerateLabelPDF(job entity.PrintJob, outPath string) (string, err
 func (a *App) PrintPDF(pdfPath string) error {
 	if err := a.printUseCase.Print(pdfPath); err != nil {
 		return fmt.Errorf("PrintPDF: %w", err)
+	}
+	return nil
+}
+
+// GetSenders returns all senders.
+func (a *App) GetSenders() ([]entity.Sender, error) {
+	senders, err := a.senderUseCase.List()
+	if err != nil {
+		return nil, fmt.Errorf("GetSenders: %w", err)
+	}
+	return senders, nil
+}
+
+// SaveSender creates or updates a sender.
+func (a *App) SaveSender(s entity.Sender) (entity.Sender, error) {
+	saved, err := a.senderUseCase.Save(s)
+	if err != nil {
+		return entity.Sender{}, fmt.Errorf("SaveSender: %w", err)
+	}
+	return saved, nil
+}
+
+// DeleteSender deletes a sender by ID.
+func (a *App) DeleteSender(id string) error {
+	if err := a.senderUseCase.Delete(id); err != nil {
+		return fmt.Errorf("DeleteSender: %w", err)
+	}
+	return nil
+}
+
+// SetDefaultSender sets the given sender as the default.
+func (a *App) SetDefaultSender(id string) error {
+	if err := a.senderUseCase.SetDefault(id); err != nil {
+		return fmt.Errorf("SetDefaultSender: %w", err)
 	}
 	return nil
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import PreviewArea from './components/preview/PreviewArea'
 import DecorationSidebar from './components/decoration/DecorationSidebar'
 import LabelSettingsPanel from './components/label/LabelSettingsPanel'
 import PrintConfirmDialog from './components/PrintConfirmDialog'
+import SenderManager from './components/sender/SenderManager'
 import { useDecorationStore } from './stores/decorationStore'
 import { useLabelStore } from './stores/labelStore'
 import { useContactStore } from './stores/contactStore'
@@ -34,6 +35,9 @@ function App() {
         </NavButton>
         <NavButton active={view === 'preview'} onClick={() => setView('preview')}>
           ラベルプレビュー
+        </NavButton>
+        <NavButton active={view === 'senders'} onClick={() => setView('senders')}>
+          差出人管理
         </NavButton>
         <NavButton active={view === 'settings'} onClick={() => setView('settings')}>
           設定
@@ -94,6 +98,11 @@ function App() {
             )}
             {showDecoPanel && <DecorationSidebar />}
           </>
+        )}
+        {view === 'senders' && (
+          <div className="flex-1 overflow-y-auto">
+            <SenderManager />
+          </div>
         )}
         {view === 'settings' && (
           <div className="flex-1 p-6">

--- a/frontend/src/components/PrintConfirmDialog.tsx
+++ b/frontend/src/components/PrintConfirmDialog.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
-import { GenerateLabelPDF, GetTempPDFPath, PrintPDF, SavePDFFileDialog } from '../../wailsjs/go/main/App'
+import { useEffect, useState } from 'react'
+import { GenerateLabelPDF, GetTempPDFPath, PrintPDF, SavePDFFileDialog, GetSenders } from '../../wailsjs/go/main/App'
 import { entity } from '../../wailsjs/go/models'
 import { useContactStore } from '../stores/contactStore'
 import { useDecorationStore } from '../stores/decorationStore'
 import { useLabelStore } from '../stores/labelStore'
+import { useSenderStore } from '../stores/senderStore'
 import { useShallow } from 'zustand/shallow'
 
 interface Props {
@@ -13,6 +14,7 @@ interface Props {
 export default function PrintConfirmDialog({ onClose }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [selectedSenderId, setSelectedSenderId] = useState('')
 
   const { contacts, selectedIds } = useContactStore(
     useShallow((s) => ({ contacts: s.contacts, selectedIds: s.selectedIds })),
@@ -21,6 +23,20 @@ export default function PrintConfirmDialog({ onClose }: Props) {
     useShallow((s) => ({ watermark: s.watermark, qrConfig: s.qrConfig })),
   )
   const layout = useLabelStore((s) => s.layout)
+  const { senders, setSenders } = useSenderStore(
+    useShallow((s) => ({ senders: s.senders, setSenders: s.setSenders })),
+  )
+
+  useEffect(() => {
+    GetSenders()
+      .then((list) => {
+        const loaded = list ?? []
+        setSenders(loaded)
+        const def = loaded.find((s) => s.isDefault)
+        if (def) setSelectedSenderId(def.id)
+      })
+      .catch(() => {})
+  }, [])
 
   const selectedContacts = contacts.filter((c) => selectedIds.has(c.id))
   const count = selectedContacts.length
@@ -39,7 +55,7 @@ export default function PrintConfirmDialog({ onClose }: Props) {
         recipient: { nameX: 0, nameY: 0, nameFont: 0, addressX: 0, addressY: 0, addressFont: 0 },
         sender: { nameX: 0, nameY: 0, nameFont: 0, addressX: 0, addressY: 0, addressFont: 0 },
       },
-      senderId: '',
+      senderId: selectedSenderId,
       labelLayout: layout,
       watermark: watermark ?? undefined,
       qrConfig: qrConfig.enabled ? qrConfig : undefined,
@@ -75,6 +91,8 @@ export default function PrintConfirmDialog({ onClose }: Props) {
     })
   }
 
+  const selectedSender = senders.find((s) => s.id === selectedSenderId)
+
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg shadow-xl w-80 p-6 space-y-4">
@@ -89,6 +107,30 @@ export default function PrintConfirmDialog({ onClose }: Props) {
             <span className="text-gray-500">用紙</span>
             <span className="font-medium text-right">{paperLabel}</span>
           </div>
+        </div>
+
+        {/* 差出人選択 */}
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">差出人</label>
+          <select
+            value={selectedSenderId}
+            onChange={(e) => setSelectedSenderId(e.target.value)}
+            className="w-full text-sm border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+          >
+            <option value="">なし</option>
+            {senders.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.familyName} {s.givenName}
+                {s.company ? ` (${s.company})` : ''}
+                {s.isDefault ? ' ★' : ''}
+              </option>
+            ))}
+          </select>
+          {selectedSender && (
+            <p className="text-xs text-gray-400 mt-1 truncate">
+              〒{selectedSender.postalCode} {selectedSender.prefecture}{selectedSender.city}{selectedSender.street}
+            </p>
+          )}
         </div>
 
         {error && (

--- a/frontend/src/components/sender/SenderManager.tsx
+++ b/frontend/src/components/sender/SenderManager.tsx
@@ -1,0 +1,280 @@
+import { useEffect, useState } from 'react'
+import { GetSenders, SaveSender, DeleteSender, SetDefaultSender } from '../../../wailsjs/go/main/App'
+import { entity } from '../../../wailsjs/go/models'
+import { useSenderStore } from '../../stores/senderStore'
+import type { Sender } from '../../types'
+
+const EMPTY_FORM: Sender = {
+  id: '',
+  familyName: '',
+  givenName: '',
+  postalCode: '',
+  prefecture: '',
+  city: '',
+  street: '',
+  building: '',
+  company: '',
+  isDefault: false,
+}
+
+export default function SenderManager() {
+  const { senders, setSenders } = useSenderStore()
+  const [editTarget, setEditTarget] = useState<Sender | null>(null)
+  const [form, setForm] = useState<Sender>(EMPTY_FORM)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  async function load() {
+    try {
+      const list = await GetSenders()
+      setSenders(list ?? [])
+    } catch (e) {
+      setError(String(e))
+    }
+  }
+
+  function startAdd() {
+    setEditTarget(EMPTY_FORM)
+    setForm(EMPTY_FORM)
+    setError(null)
+  }
+
+  function startEdit(s: Sender) {
+    setEditTarget(s)
+    setForm({ ...s })
+    setError(null)
+  }
+
+  function cancelEdit() {
+    setEditTarget(null)
+    setError(null)
+  }
+
+  async function handleSave() {
+    setLoading(true)
+    setError(null)
+    try {
+      const saved = await SaveSender(entity.Sender.createFrom(form))
+      setSenders(
+        form.id
+          ? senders.map((s) => (s.id === saved.id ? saved : s))
+          : [...senders, saved],
+      )
+      setEditTarget(null)
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm('この差出人を削除しますか？')) return
+    setLoading(true)
+    setError(null)
+    try {
+      await DeleteSender(id)
+      setSenders(senders.filter((s) => s.id !== id))
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleSetDefault(id: string) {
+    setLoading(true)
+    setError(null)
+    try {
+      await SetDefaultSender(id)
+      setSenders(senders.map((s) => ({ ...s, isDefault: s.id === id })))
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-800">差出人管理</h2>
+        <button
+          onClick={startAdd}
+          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          追加
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-xs text-red-600 bg-red-50 rounded px-2 py-1 mb-3">{error}</p>
+      )}
+
+      {/* 差出人一覧 */}
+      <div className="space-y-2 mb-6">
+        {senders.length === 0 && (
+          <p className="text-sm text-gray-400">差出人が登録されていません</p>
+        )}
+        {senders.map((s) => (
+          <div
+            key={s.id}
+            className="flex items-center justify-between bg-white border border-gray-200 rounded-lg px-4 py-3"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-gray-800">
+                  {s.familyName} {s.givenName}
+                  {s.company && <span className="text-gray-500 ml-1">({s.company})</span>}
+                </span>
+                {s.isDefault && (
+                  <span className="text-xs px-1.5 py-0.5 bg-blue-100 text-blue-700 rounded">
+                    デフォルト
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-gray-500 mt-0.5 truncate">
+                〒{s.postalCode} {s.prefecture}{s.city}{s.street}
+                {s.building && ` ${s.building}`}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 ml-3 shrink-0">
+              {!s.isDefault && (
+                <button
+                  onClick={() => handleSetDefault(s.id)}
+                  disabled={loading}
+                  className="text-xs text-gray-500 hover:text-blue-600 disabled:opacity-40"
+                >
+                  デフォルトに設定
+                </button>
+              )}
+              <button
+                onClick={() => startEdit(s)}
+                className="text-xs text-gray-500 hover:text-gray-800"
+              >
+                編集
+              </button>
+              <button
+                onClick={() => handleDelete(s.id)}
+                disabled={loading}
+                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40"
+              >
+                削除
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 編集フォーム */}
+      {editTarget !== null && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3">
+          <h3 className="text-sm font-semibold text-gray-700">
+            {form.id ? '差出人を編集' : '差出人を追加'}
+          </h3>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field
+              label="姓"
+              value={form.familyName}
+              onChange={(v) => setForm({ ...form, familyName: v })}
+            />
+            <Field
+              label="名"
+              value={form.givenName}
+              onChange={(v) => setForm({ ...form, givenName: v })}
+            />
+          </div>
+          <Field
+            label="会社名"
+            value={form.company}
+            onChange={(v) => setForm({ ...form, company: v })}
+          />
+          <Field
+            label="郵便番号"
+            value={form.postalCode}
+            onChange={(v) => setForm({ ...form, postalCode: v })}
+            placeholder="000-0000"
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <Field
+              label="都道府県"
+              value={form.prefecture}
+              onChange={(v) => setForm({ ...form, prefecture: v })}
+            />
+            <Field
+              label="市区町村"
+              value={form.city}
+              onChange={(v) => setForm({ ...form, city: v })}
+            />
+          </div>
+          <Field
+            label="番地"
+            value={form.street}
+            onChange={(v) => setForm({ ...form, street: v })}
+          />
+          <Field
+            label="建物名・部屋番号"
+            value={form.building}
+            onChange={(v) => setForm({ ...form, building: v })}
+          />
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={form.isDefault}
+              onChange={(e) => setForm({ ...form, isDefault: e.target.checked })}
+              className="rounded"
+            />
+            デフォルト差出人に設定
+          </label>
+
+          <div className="flex gap-2 pt-1">
+            <button
+              onClick={handleSave}
+              disabled={loading}
+              className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? '保存中...' : '保存'}
+            </button>
+            <button
+              onClick={cancelEdit}
+              disabled={loading}
+              className="px-4 py-1.5 text-sm border border-gray-300 rounded text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+            >
+              キャンセル
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+}) {
+  return (
+    <div>
+      <label className="block text-xs text-gray-500 mb-1">{label}</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full text-sm border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+      />
+    </div>
+  )
+}

--- a/frontend/src/stores/senderStore.ts
+++ b/frontend/src/stores/senderStore.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand'
+import type { Sender } from '../types'
+
+interface SenderState {
+  senders: Sender[]
+  setSenders: (senders: Sender[]) => void
+}
+
+export const useSenderStore = create<SenderState>((set) => ({
+  senders: [],
+  setSenders: (senders) => set({ senders }),
+}))

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -98,4 +98,4 @@ export interface ImportResult {
   errors: string[]
 }
 
-export type View = 'contacts' | 'preview' | 'settings'
+export type View = 'contacts' | 'preview' | 'senders' | 'settings'

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -51,3 +51,11 @@ export function SearchContacts(arg1:string):Promise<Array<entity.Contact>>;
 export function SetContactGroups(arg1:string,arg2:Array<string>):Promise<void>;
 
 export function UploadWatermark(arg1:string):Promise<entity.Watermark>;
+
+export function GetSenders():Promise<Array<entity.Sender>>;
+
+export function SaveSender(arg1:entity.Sender):Promise<entity.Sender>;
+
+export function DeleteSender(arg1:string):Promise<void>;
+
+export function SetDefaultSender(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -101,3 +101,19 @@ export function SetContactGroups(arg1, arg2) {
 export function UploadWatermark(arg1) {
   return window['go']['main']['App']['UploadWatermark'](arg1);
 }
+
+export function GetSenders() {
+  return window['go']['main']['App']['GetSenders']();
+}
+
+export function SaveSender(arg1) {
+  return window['go']['main']['App']['SaveSender'](arg1);
+}
+
+export function DeleteSender(arg1) {
+  return window['go']['main']['App']['DeleteSender'](arg1);
+}
+
+export function SetDefaultSender(arg1) {
+  return window['go']['main']['App']['SetDefaultSender'](arg1);
+}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -174,6 +174,36 @@ export namespace entity {
 	        this.position = source["position"];
 	    }
 	}
+	export class Sender {
+	    id: string;
+	    familyName: string;
+	    givenName: string;
+	    postalCode: string;
+	    prefecture: string;
+	    city: string;
+	    street: string;
+	    building: string;
+	    company: string;
+	    isDefault: boolean;
+
+	    static createFrom(source: any = {}) {
+	        return new Sender(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.familyName = source["familyName"];
+	        this.givenName = source["givenName"];
+	        this.postalCode = source["postalCode"];
+	        this.prefecture = source["prefecture"];
+	        this.city = source["city"];
+	        this.street = source["street"];
+	        this.building = source["building"];
+	        this.company = source["company"];
+	        this.isDefault = source["isDefault"];
+	    }
+	}
 	export class Watermark {
 	    id: string;
 	    name: string;

--- a/internal/usecase/sender_usecase.go
+++ b/internal/usecase/sender_usecase.go
@@ -1,0 +1,55 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"atena-label/internal/entity"
+	"atena-label/internal/repository"
+)
+
+type SenderUseCase struct {
+	repo repository.SenderRepository
+}
+
+func NewSenderUseCase(repo repository.SenderRepository) *SenderUseCase {
+	return &SenderUseCase{repo: repo}
+}
+
+func (uc *SenderUseCase) List() ([]entity.Sender, error) {
+	return uc.repo.FindAll()
+}
+
+func (uc *SenderUseCase) Save(s entity.Sender) (entity.Sender, error) {
+	if s.ID == "" {
+		s.ID = uuid.New().String()
+		if err := uc.repo.Create(&s); err != nil {
+			return entity.Sender{}, fmt.Errorf("create sender: %w", err)
+		}
+	} else {
+		if err := uc.repo.Update(&s); err != nil {
+			return entity.Sender{}, fmt.Errorf("update sender: %w", err)
+		}
+	}
+	return s, nil
+}
+
+func (uc *SenderUseCase) Delete(id string) error {
+	if id == "" {
+		return fmt.Errorf("差出人IDは必須です")
+	}
+	return uc.repo.Delete(id)
+}
+
+func (uc *SenderUseCase) SetDefault(id string) error {
+	s, err := uc.repo.FindByID(id)
+	if err != nil {
+		return fmt.Errorf("find sender: %w", err)
+	}
+	if s == nil {
+		return fmt.Errorf("sender %s: not found", id)
+	}
+	s.IsDefault = true
+	return uc.repo.Update(s)
+}

--- a/main.go
+++ b/main.go
@@ -45,11 +45,12 @@ func main() {
 	qrCodeUC := usecase.NewQRCodeUseCase(&qrpkg.Generator{})
 
 	senderRepo := dbpkg.NewSenderRepo(db)
+	senderUC := usecase.NewSenderUseCase(senderRepo)
 	pdfGen := pdfpkg.NewGenerator("")
 	printUC := usecase.NewPrintUseCase(contactRepo, senderRepo, pdfGen, &printer.OSPrinter{})
 
 	postalRepo := postal.NewRepo()
-	app := NewApp(contactUC, csvUC, groupUC, watermarkUC, qrCodeUC, printUC, postalRepo)
+	app := NewApp(contactUC, csvUC, groupUC, watermarkUC, qrCodeUC, printUC, senderUC, postalRepo)
 
 	err = wails.Run(&options.App{
 		Title:  "Atena ラベル印刷",


### PR DESCRIPTION
## Summary

- `SenderUseCase` を追加し CRUD と `SetDefault` を実装
- `app.go` に `GetSenders` / `SaveSender` / `DeleteSender` / `SetDefaultSender` をバインド
- `SenderManager.tsx` で差出人の一覧・追加・編集・削除・デフォルト設定 UI を実装
- 印刷確認ダイアログに差出人セレクターを追加（デフォルト差出人を自動選択）
- Wails バインディング (`App.js` / `App.d.ts` / `models.ts`) に `Sender` クラスを追加

## Test plan

- [x] サイドバーから「差出人管理」に遷移できる
- [x] 差出人を追加・編集・削除できる
- [ ] デフォルト差出人を設定でき、印刷ダイアログで自動選択される
- [ ] 印刷確認ダイアログで差出人を切り替えられる
- [ ] `go build` / `npx tsc --noEmit` がエラーなし

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 差出人管理機能を追加しました。差出人の追加、編集、削除、およびデフォルト差出人の設定が可能になります。
* 印刷確認時に差出人を選択できるドロップダウンを追加し、選択した差出人の住所情報をプレビューで表示できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->