### PR TITLE
fix: フォントパス絶対パスが失われるバグを修正

### DIFF
--- a/internal/infrastructure/pdf/label_pdf.go
+++ b/internal/infrastructure/pdf/label_pdf.go
@@ -70,12 +70,16 @@ func (g *Generator) GenerateLabelPDF(
 	pdf.SetCompression(true)
 
 	// Register Japanese font if available.
+	// Use AddUTF8FontFromBytes to avoid gofpdf's internal filepath.Join
+	// mangling absolute paths when its fontpath is non-empty.
 	const fontName = "jfont"
 	hasJFont := false
 	if g.fontPath != "" {
-		pdf.AddUTF8Font(fontName, "", g.fontPath)
-		if pdf.Error() == nil {
-			hasJFont = true
+		if fontBytes, err := os.ReadFile(g.fontPath); err == nil {
+			pdf.AddUTF8FontFromBytes(fontName, "", fontBytes)
+			if pdf.Error() == nil {
+				hasJFont = true
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `gofpdf.AddUTF8Font` は内部で `filepath.Join(fontpath, fileStr)` を実行するため、絶対パスを渡すと fontpath との結合で先頭の `/` が失われ `stat System/Library/Fonts/... no such file or directory` エラーになっていた
- `AddUTF8FontFromBytes` でフォントを読み込んでバイトとして渡す方式に変更して解消

## Test plan

- [ ] macOS でラベル印刷 / PDF保存が成功すること（ヒラギノ明朝が読み込まれる）
- [ ] フォントが見つからない環境でも Courier にフォールバックして PDF 生成が成功すること
- [ ] `go build` が通ること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * PDFラベルの日本語フォント処理がより安定しました。フォント読み込みのエラーハンドリングを改善し、信頼性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->