### PR TITLE
feat: ラベル横書き対応（プレビュー/PDF印刷の両対応） #30

### DIFF
--- a/frontend/src/components/PrintConfirmDialog.tsx
+++ b/frontend/src/components/PrintConfirmDialog.tsx
@@ -22,7 +22,9 @@ export default function PrintConfirmDialog({ onClose }: Props) {
   const { watermark, qrConfig } = useDecorationStore(
     useShallow((s) => ({ watermark: s.watermark, qrConfig: s.qrConfig })),
   )
-  const layout = useLabelStore((s) => s.layout)
+  const { layout, orientation } = useLabelStore(
+    useShallow((s) => ({ layout: s.layout, orientation: s.orientation })),
+  )
   const { senders, setSenders } = useSenderStore(
     useShallow((s) => ({ senders: s.senders, setSenders: s.setSenders })),
   )
@@ -49,7 +51,7 @@ export default function PrintConfirmDialog({ onClose }: Props) {
       template: {
         id: '',
         name: 'default',
-        orientation: 'vertical',
+        orientation,
         labelWidth: layout.labelWidth,
         labelHeight: layout.labelHeight,
         recipient: { nameX: 0, nameY: 0, nameFont: 0, addressX: 0, addressY: 0, addressFont: 0 },

--- a/frontend/src/components/label/LabelSettingsPanel.tsx
+++ b/frontend/src/components/label/LabelSettingsPanel.tsx
@@ -89,8 +89,13 @@ function matchPreset(layout: LabelLayout): string {
 }
 
 export default function LabelSettingsPanel() {
-  const { layout, setLayout } = useLabelStore(
-    useShallow((s) => ({ layout: s.layout, setLayout: s.setLayout })),
+  const { layout, setLayout, orientation, setOrientation } = useLabelStore(
+    useShallow((s) => ({
+      layout: s.layout,
+      setLayout: s.setLayout,
+      orientation: s.orientation,
+      setOrientation: s.setOrientation,
+    })),
   )
 
   const currentPreset = matchPreset(layout)
@@ -128,6 +133,26 @@ export default function LabelSettingsPanel() {
 
   return (
     <div className="space-y-4">
+      {/* 書字方向 */}
+      <div>
+        <p className="text-xs font-medium text-gray-700 mb-1">書字方向</p>
+        <div className="flex rounded border border-gray-300 overflow-hidden text-xs">
+          {(['vertical', 'horizontal'] as const).map((o) => (
+            <button
+              key={o}
+              onClick={() => setOrientation(o)}
+              className={`flex-1 py-1 transition-colors ${
+                orientation === o
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              {o === 'vertical' ? '縦書き' : '横書き'}
+            </button>
+          ))}
+        </div>
+      </div>
+
       {/* 用紙タイプ */}
       <div>
         <label className="block text-xs font-medium text-gray-700 mb-1">用紙タイプ</label>

--- a/frontend/src/components/preview/LabelCanvas.tsx
+++ b/frontend/src/components/preview/LabelCanvas.tsx
@@ -6,7 +6,7 @@ import { drawVerticalBlock } from '../../lib/verticalText'
 const MM_TO_PX = 96 / 25.4 // ≈ 3.78
 
 /**
- * デフォルトテンプレート: A4 12面ラベル (86.4×42.3mm)
+ * デフォルトテンプレート: A4 12面ラベル (86.4×42.3mm) 縦書き
  * テンプレート選択 UI が実装されるまでのフォールバック用。
  */
 export const DEFAULT_TEMPLATE: Template = {
@@ -35,6 +35,39 @@ export const DEFAULT_TEMPLATE: Template = {
     nameFont: 6.5,
     addressX: 8,  // 差出人住所ブロック右端 (mm)
     addressY: 24,
+    addressFont: 5.5,
+  },
+}
+
+/**
+ * デフォルトテンプレート: A4 12面ラベル (86.4×42.3mm) 横書き
+ */
+export const DEFAULT_TEMPLATE_HORIZONTAL: Template = {
+  id: 'default-a4-12-h',
+  name: '標準 (A4 12面) 横書き',
+  orientation: 'horizontal',
+  labelWidth: 86.4,
+  labelHeight: 42.3,
+  postalCode: {
+    x: 5,
+    y: 3,
+    digitSpacing: 7,
+    fontSize: 9,
+  },
+  recipient: {
+    nameX: 5,
+    nameY: 13,
+    nameFont: 12,
+    addressX: 5,
+    addressY: 24,
+    addressFont: 8.5,
+  },
+  sender: {
+    nameX: 50,
+    nameY: 33,
+    nameFont: 6.5,
+    addressX: 50,
+    addressY: 37,
     addressFont: 5.5,
   },
 }
@@ -139,6 +172,20 @@ function renderLabel(
     }
   }
 
+  if (tpl.orientation === 'horizontal') {
+    renderHorizontalLabel(ctx, contact, tpl, s)
+  } else {
+    renderVerticalLabel(ctx, contact, tpl, s)
+  }
+}
+
+/** 縦書きラベルの宛先・差出人描画 */
+function renderVerticalLabel(
+  ctx: CanvasRenderingContext2D,
+  contact: Contact,
+  tpl: Template,
+  s: number,
+): void {
   // ─── 宛先 氏名 ───────────────────────────────────────────
   {
     const rc = tpl.recipient
@@ -181,14 +228,52 @@ function renderLabel(
       convertNumbers: true,
     })
   }
+}
 
-  // ─── 差出人（会社名があれば部署・会社を優先） ──────────────
-  const senderName = contact.company
-    ? `${contact.company}${contact.department ? `　${contact.department}` : ''}`
-    : null
+/** 横書きラベルの宛先・差出人描画 */
+function renderHorizontalLabel(
+  ctx: CanvasRenderingContext2D,
+  contact: Contact,
+  tpl: Template,
+  s: number,
+): void {
+  const serifFont = '"Hiragino Mincho ProN", "Yu Mincho", "MS PMincho", serif'
 
-  // 差出人エリアは将来 Sender エンティティで置き換える
-  // (Phase 6: 差出人管理) — 現状は連絡先の会社情報をダミーで表示しない
+  // ─── 宛先 氏名 ───────────────────────────────────────────
+  {
+    const rc = tpl.recipient
+    const nameFontPx = mm(rc.nameFont / 2.835, s)
+    const honorific = contact.honorific || '様'
+    const fullName = `${contact.familyName}${contact.givenName}　${honorific}`
+
+    ctx.fillStyle = '#111827'
+    ctx.font = `${nameFontPx}px ${serifFont}`
+    ctx.textAlign = 'left'
+    ctx.textBaseline = 'top'
+    ctx.fillText(fullName, mm(rc.nameX, s), mm(rc.nameY, s))
+  }
+
+  // ─── 宛先 住所 ───────────────────────────────────────────
+  {
+    const rc = tpl.recipient
+    const addrFontPx = mm(rc.addressFont / 2.835, s)
+    const lineH = addrFontPx * 1.5
+
+    const addrLines = [
+      `${contact.prefecture}${contact.city}`,
+      `${contact.street}${contact.building ? `　${contact.building}` : ''}`,
+    ].filter(Boolean)
+
+    ctx.fillStyle = '#111827'
+    ctx.font = `${addrFontPx}px ${serifFont}`
+    ctx.textAlign = 'left'
+    ctx.textBaseline = 'top'
+
+    addrLines.forEach((line, i) => {
+      ctx.fillText(line, mm(rc.addressX, s), mm(rc.addressY, s) + i * lineH)
+    })
+  }
+
+  // ─── 差出人エリアは将来 Sender エンティティで置き換える ──────
   // 仕様: 差出人は別エンティティなので、ここでは表示領域の余白のみ確保
-  void senderName // 未使用警告抑制
 }

--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -3,9 +3,10 @@ import { useShallow } from 'zustand/shallow'
 import { useContactStore } from '../../stores/contactStore'
 import { usePreviewStore } from '../../stores/previewStore'
 import { useDecorationStore } from '../../stores/decorationStore'
-import LabelCanvas, { DEFAULT_TEMPLATE } from './LabelCanvas'
+import LabelCanvas, { DEFAULT_TEMPLATE, DEFAULT_TEMPLATE_HORIZONTAL } from './LabelCanvas'
 import WatermarkLayer from './WatermarkLayer'
 import QROverlay from './QROverlay'
+import { useLabelStore } from '../../stores/labelStore'
 import type { Contact, Template, Watermark, QRConfig } from '../../types'
 
 const ZOOM_MIN = 0.5
@@ -29,6 +30,7 @@ export default function PreviewArea() {
   const { watermark, qrConfig } = useDecorationStore(
     useShallow((s) => ({ watermark: s.watermark, qrConfig: s.qrConfig })),
   )
+  const orientation = useLabelStore((s) => s.orientation)
 
   const selectedContacts = contacts.filter((c) => selectedIds.has(c.id))
 
@@ -44,7 +46,10 @@ export default function PreviewArea() {
   const safeIndex = Math.max(0, Math.min(previewContactIndex, selectedContacts.length - 1))
   const currentContact: Contact | null = selectedContacts[safeIndex] ?? null
 
-  const template: Template = selectedTemplate ?? DEFAULT_TEMPLATE
+  const defaultTpl = orientation === 'horizontal' ? DEFAULT_TEMPLATE_HORIZONTAL : DEFAULT_TEMPLATE
+  const template: Template = selectedTemplate
+    ? { ...selectedTemplate, orientation }
+    : { ...defaultTpl, orientation }
 
   const zoomIn = () => setZoom(Math.min(ZOOM_MAX, Math.round((zoom + ZOOM_STEP) * 100) / 100))
   const zoomOut = () => setZoom(Math.max(ZOOM_MIN, Math.round((zoom - ZOOM_STEP) * 100) / 100))

--- a/frontend/src/stores/labelStore.ts
+++ b/frontend/src/stores/labelStore.ts
@@ -16,18 +16,22 @@ const defaultLayout: LabelLayout = {
 
 interface LabelState {
   layout: LabelLayout
+  orientation: 'vertical' | 'horizontal'
   selectedSender: Sender | null
   showPanel: boolean
   setLayout: (layout: Partial<LabelLayout>) => void
+  setOrientation: (orientation: 'vertical' | 'horizontal') => void
   setSelectedSender: (sender: Sender | null) => void
   togglePanel: () => void
 }
 
 export const useLabelStore = create<LabelState>((set, get) => ({
   layout: defaultLayout,
+  orientation: 'vertical',
   selectedSender: null,
   showPanel: false,
   setLayout: (layout) => set({ layout: { ...get().layout, ...layout } }),
+  setOrientation: (orientation) => set({ orientation }),
   setSelectedSender: (sender) => set({ selectedSender: sender }),
   togglePanel: () => set({ showPanel: !get().showPanel }),
 }))


### PR DESCRIPTION
## Summary

- `labelStore` に `orientation: 'vertical' | 'horizontal'` を追加
- `LabelSettingsPanel` に縦書き/横書きトグルボタンを追加（用紙タイプ選択の上部）
- `LabelCanvas` に横書きレンダリングを実装（`renderHorizontalLabel`）。横書きデフォルトテンプレート `DEFAULT_TEMPLATE_HORIZONTAL` も追加
- `PreviewArea` でストアの orientation を template に上書き反映し、プレビューに即時反映
- `PrintConfirmDialog` の `buildJob()` で orientation を固定値 `'vertical'` からストア値に変更
- PDF生成 (`label_pdf.go`) は既に vertical/horizontal 両対応済みのため変更なし

## Test plan

- [x] `go test ./internal/...` — 全パス
- [x] `npx vitest --run` — 40テスト全パス
- [x] `tsc --noEmit` — 型エラーなし
- [ ] 縦書きモードで既存動作が回帰しないことを手動確認
- [ ] 横書きモードに切替後、プレビュー Canvas が横書きで表示されることを確認
- [ ] PDF保存で横書きラベルが出力されることを確認

closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ラベルの向きを「縦書き」または「横書き」から選択できるようになりました。
  * ラベルプレビューと印刷に横書きテンプレートが対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->