### PR TITLE
fix: PDF保存時の "undefined font: jfont" エラーを修正

### DIFF
--- a/internal/infrastructure/pdf/label_pdf.go
+++ b/internal/infrastructure/pdf/label_pdf.go
@@ -23,8 +23,13 @@ type Generator struct {
 func NewGenerator(fontPath string) *Generator {
 	g := &Generator{}
 	if fontPath != "" {
-		g.fontPath = fontPath
-		g.fontBytes, _ = loadAndValidateFont(fontPath)
+		if fb, ok := loadAndValidateFont(fontPath); ok {
+			g.fontPath = fontPath
+			g.fontBytes = fb
+		} else {
+			// Explicit path is unusable; fall back to system font detection.
+			g.fontBytes, g.fontPath = detectAndLoadJapaneseFont()
+		}
 	} else {
 		g.fontBytes, g.fontPath = detectAndLoadJapaneseFont()
 	}


### PR DESCRIPTION
## Summary

- `AddUTF8FontFromBytes` は TTC/OTF ファイルをエラーなく受け付けるが、`pdf.Output()` 時に `"undefined font: jfont"` で失敗するケースがある
- フォントをアプリ起動時に事前検証（テスト PDF を実際に生成して出力まで確認）し、gofpdf で使用できないフォントを候補から除外するよう修正
- 使用可能なフォントが見つからない場合は Courier にフォールバックし、PDF 生成自体は必ず成功するようにした

## Changes

- `Generator` struct に `fontBytes` フィールドを追加（検証済みフォントバイトをキャッシュ）
- `loadAndValidateFont()`: フォントファイルを読み込み、テスト PDF を実際に出力して使用可否を確認する
- `detectAndLoadJapaneseFont()`: 候補を順に試して最初に使えるフォントを返す
- `GenerateLabelPDF()`: 毎回ファイルを読み込む代わりにキャッシュ済み `fontBytes` を使用

## Test plan

- [ ] ラベル印刷ボタン → PDF保存 でエラーが出ずに PDF が保存されることを確認
- [ ] 日本語フォントが利用可能な環境で日本語テキストが正しく表示されることを確認
- [ ] フォントが利用不可の環境でも PDF 生成が失敗しないことを確認

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * PDFラベル生成時のフォント処理を改善し、より堅牢な検証フローを実装しました。
  * プラットフォーム固有のフォント検出機能を強化し、使用可能なフォントの自動選択精度を向上させました。
  * フォント利用不可時のフォールバック処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->