### PR TITLE
ラベルプレビューのフォント操作を上部ツールバー化

### DIFF
--- a/frontend/src/components/preview/LabelEditorOverlay.tsx
+++ b/frontend/src/components/preview/LabelEditorOverlay.tsx
@@ -1,205 +1,42 @@
 import { useEffect, useRef } from 'react'
 import type { Template } from '../../types'
+import {
+  applyFontDelta,
+  applyMove,
+  buildEditableBoxes,
+  type EditableFieldId,
+} from './labelEditorTemplate'
 
 /** 1mm あたりのピクセル数 (LabelCanvas と同じ定数) */
 const MM_TO_PX = 96 / 25.4
 
-// ── バウンディングボックスの計算 ────────────────────────────────────────────
-
-interface Box {
-  id: string
-  label: string
-  /** 表示上の左端 (mm) */
-  visualXMm: number
-  /** 表示上の上端 (mm) */
-  visualYMm: number
-  widthMm: number
-  heightMm: number
-  fontPt: number
-  fontFamily: 'serif' | 'sans-serif'
-  bold: boolean
-  color: string
-}
-
-function buildBoxes(tpl: Template): Box[] {
-  const isV = tpl.orientation === 'vertical'
-  const lh = tpl.labelHeight
-  const lw = tpl.labelWidth
-  const boxes: Box[] = []
-
-  // ── 郵便番号 ──────────────────────────────────────────────────────────────
-  if (tpl.postalCode) {
-    const pc = tpl.postalCode
-    boxes.push({
-      id: 'postalCode',
-      label: '〒 郵便番号',
-      visualXMm: pc.x - pc.digitSpacing * 0.4,
-      visualYMm: pc.y,
-      widthMm: pc.digitSpacing * 8.5,
-      heightMm: (pc.fontSize / 2.835) * 1.8,
-      fontPt: pc.fontSize,
-      fontFamily: pc.fontFamily ?? 'sans-serif',
-      bold: pc.bold ?? false,
-      color: '#3b82f6',
-    })
-  }
-
-  const rc = tpl.recipient
-  if (isV) {
-    // 縦書き: nameX / addressX は右端
-    const nw = (rc.nameFont / 2.835) * 2.5
-    boxes.push({
-      id: 'recipientName',
-      label: '宛名',
-      visualXMm: rc.nameX - nw,
-      visualYMm: rc.nameY,
-      widthMm: nw,
-      heightMm: Math.max(5, lh - rc.nameY - 2),
-      fontPt: rc.nameFont,
-      fontFamily: rc.nameFontFamily ?? 'serif',
-      bold: rc.nameBold ?? false,
-      color: '#10b981',
-    })
-    const aw = (rc.addressFont / 2.835) * 2.5
-    boxes.push({
-      id: 'recipientAddr',
-      label: '住所',
-      visualXMm: rc.addressX - aw,
-      visualYMm: rc.addressY,
-      widthMm: aw,
-      heightMm: Math.max(5, lh - rc.addressY - 2),
-      fontPt: rc.addressFont,
-      fontFamily: rc.addressFontFamily ?? 'serif',
-      bold: rc.addressBold ?? false,
-      color: '#f59e0b',
-    })
-  } else {
-    // 横書き: nameX / addressX は左端
-    boxes.push({
-      id: 'recipientName',
-      label: '宛名',
-      visualXMm: rc.nameX,
-      visualYMm: rc.nameY,
-      widthMm: Math.max(10, lw - rc.nameX - 2),
-      heightMm: (rc.nameFont / 2.835) * 1.8,
-      fontPt: rc.nameFont,
-      fontFamily: rc.nameFontFamily ?? 'serif',
-      bold: rc.nameBold ?? false,
-      color: '#10b981',
-    })
-    boxes.push({
-      id: 'recipientAddr',
-      label: '住所',
-      visualXMm: rc.addressX,
-      visualYMm: rc.addressY,
-      widthMm: Math.max(10, lw - rc.addressX - 2),
-      heightMm: (rc.addressFont / 2.835) * 3.5,
-      fontPt: rc.addressFont,
-      fontFamily: rc.addressFontFamily ?? 'serif',
-      bold: rc.addressBold ?? false,
-      color: '#f59e0b',
-    })
-  }
-
-  // 差出人は LabelCanvas に描画実装後に有効化する (TODO: sender rendering)
-
-  return boxes
-}
-
-// ── テンプレート更新ヘルパー ────────────────────────────────────────────────
-
-function applyMove(tpl: Template, id: string, dxMm: number, dyMm: number): Template {
-  const r = (v: number) => Math.round(v * 10) / 10
-  switch (id) {
-    case 'postalCode':
-      if (!tpl.postalCode) return tpl
-      return { ...tpl, postalCode: { ...tpl.postalCode, x: r(tpl.postalCode.x + dxMm), y: r(tpl.postalCode.y + dyMm) } }
-    case 'recipientName':
-      return { ...tpl, recipient: { ...tpl.recipient, nameX: r(tpl.recipient.nameX + dxMm), nameY: r(tpl.recipient.nameY + dyMm) } }
-    case 'recipientAddr':
-      return { ...tpl, recipient: { ...tpl.recipient, addressX: r(tpl.recipient.addressX + dxMm), addressY: r(tpl.recipient.addressY + dyMm) } }
-    case 'senderName':
-      return { ...tpl, sender: { ...tpl.sender, nameX: r(tpl.sender.nameX + dxMm), nameY: r(tpl.sender.nameY + dyMm) } }
-    case 'senderAddr':
-      return { ...tpl, sender: { ...tpl.sender, addressX: r(tpl.sender.addressX + dxMm), addressY: r(tpl.sender.addressY + dyMm) } }
-    default:
-      return tpl
-  }
-}
-
-/** fontPt を delta だけ変更 (0.5pt 刻み・最小 4pt) */
-function applyFontDelta(tpl: Template, id: string, delta: number): Template {
-  const r = (v: number) => Math.max(4, Math.round(v * 2) / 2)
-  switch (id) {
-    case 'postalCode':
-      if (!tpl.postalCode) return tpl
-      return { ...tpl, postalCode: { ...tpl.postalCode, fontSize: r(tpl.postalCode.fontSize + delta) } }
-    case 'recipientName':
-      return { ...tpl, recipient: { ...tpl.recipient, nameFont: r(tpl.recipient.nameFont + delta) } }
-    case 'recipientAddr':
-      return { ...tpl, recipient: { ...tpl.recipient, addressFont: r(tpl.recipient.addressFont + delta) } }
-    case 'senderName':
-      return { ...tpl, sender: { ...tpl.sender, nameFont: r(tpl.sender.nameFont + delta) } }
-    case 'senderAddr':
-      return { ...tpl, sender: { ...tpl.sender, addressFont: r(tpl.sender.addressFont + delta) } }
-    default:
-      return tpl
-  }
-}
-
-/** フォントファミリーを変更 */
-function applyFontFamily(tpl: Template, id: string, family: 'serif' | 'sans-serif'): Template {
-  switch (id) {
-    case 'postalCode':
-      if (!tpl.postalCode) return tpl
-      return { ...tpl, postalCode: { ...tpl.postalCode, fontFamily: family } }
-    case 'recipientName':
-      return { ...tpl, recipient: { ...tpl.recipient, nameFontFamily: family } }
-    case 'recipientAddr':
-      return { ...tpl, recipient: { ...tpl.recipient, addressFontFamily: family } }
-    case 'senderName':
-      return { ...tpl, sender: { ...tpl.sender, nameFontFamily: family } }
-    case 'senderAddr':
-      return { ...tpl, sender: { ...tpl.sender, addressFontFamily: family } }
-    default:
-      return tpl
-  }
-}
-
-/** 太字フラグをトグル */
-function applyBold(tpl: Template, id: string, bold: boolean): Template {
-  switch (id) {
-    case 'postalCode':
-      if (!tpl.postalCode) return tpl
-      return { ...tpl, postalCode: { ...tpl.postalCode, bold } }
-    case 'recipientName':
-      return { ...tpl, recipient: { ...tpl.recipient, nameBold: bold } }
-    case 'recipientAddr':
-      return { ...tpl, recipient: { ...tpl.recipient, addressBold: bold } }
-    case 'senderName':
-      return { ...tpl, sender: { ...tpl.sender, nameBold: bold } }
-    case 'senderAddr':
-      return { ...tpl, sender: { ...tpl.sender, addressBold: bold } }
-    default:
-      return tpl
-  }
-}
-
-// ── コンポーネント ──────────────────────────────────────────────────────────
-
 interface Props {
   template: Template
   zoom: number
+  selectedFieldId: EditableFieldId | null
+  onSelectField: (id: EditableFieldId) => void
   onTemplateChange: (t: Template) => void
 }
 
-export default function LabelEditorOverlay({ template, zoom, onTemplateChange }: Props) {
-  const boxes = buildBoxes(template)
+export default function LabelEditorOverlay({
+  template,
+  zoom,
+  selectedFieldId,
+  onSelectField,
+  onTemplateChange,
+}: Props) {
+  const boxes = buildEditableBoxes(template)
 
-  // 移動ドラッグ用 refs
-  const moveListeners = useRef<{ move: (e: MouseEvent) => void; up: () => void; blur: () => void } | null>(null)
-  // リサイズドラッグ用 refs
-  const resizeListeners = useRef<{ move: (e: MouseEvent) => void; up: () => void; blur: () => void } | null>(null)
+  const moveListeners = useRef<{
+    move: (e: MouseEvent) => void
+    up: () => void
+    blur: () => void
+  } | null>(null)
+  const resizeListeners = useRef<{
+    move: (e: MouseEvent) => void
+    up: () => void
+    blur: () => void
+  } | null>(null)
 
   useEffect(() => {
     return () => {
@@ -216,17 +53,18 @@ export default function LabelEditorOverlay({ template, zoom, onTemplateChange }:
     }
   }, [])
 
-  /** ボックス本体ドラッグ → 位置移動 */
-  function startMove(e: React.MouseEvent, id: string) {
+  function startMove(e: React.MouseEvent, id: EditableFieldId) {
     e.stopPropagation()
     e.preventDefault()
-    // 前回のドラッグリスナーが残っていれば先に除去
+    onSelectField(id)
+
     if (moveListeners.current) {
       window.removeEventListener('mousemove', moveListeners.current.move)
       window.removeEventListener('mouseup', moveListeners.current.up)
       window.removeEventListener('blur', moveListeners.current.blur)
       moveListeners.current = null
     }
+
     const startX = e.clientX
     const startY = e.clientY
     const pxPerMm = zoom * MM_TO_PX
@@ -247,25 +85,26 @@ export default function LabelEditorOverlay({ template, zoom, onTemplateChange }:
     window.addEventListener('blur', cleanup)
   }
 
-  /** 右下ハンドルドラッグ → フォントサイズ変更 (1.2pt/mm) */
-  function startResize(e: React.MouseEvent, id: string, baseFontPt: number) {
+  function startResize(e: React.MouseEvent, id: EditableFieldId, baseFontPt: number) {
     e.stopPropagation()
     e.preventDefault()
-    // 前回のドラッグリスナーが残っていれば先に除去
+    onSelectField(id)
+
     if (resizeListeners.current) {
       window.removeEventListener('mousemove', resizeListeners.current.move)
       window.removeEventListener('mouseup', resizeListeners.current.up)
       window.removeEventListener('blur', resizeListeners.current.blur)
       resizeListeners.current = null
     }
+
     const startX = e.clientX
     const pxPerMm = zoom * MM_TO_PX
     const base = template
 
     const onMove = (me: MouseEvent) => {
       const dxMm = (me.clientX - startX) / pxPerMm
-      const newFont = Math.max(4, Math.round((baseFontPt + dxMm * 1.2) * 2) / 2)
-      onTemplateChange(applyFontDelta(base, id, newFont - baseFontPt))
+      const nextFont = Math.max(4, Math.round((baseFontPt + dxMm * 1.2) * 2) / 2)
+      onTemplateChange(applyFontDelta(base, id, nextFont - baseFontPt))
     }
     const cleanup = () => {
       window.removeEventListener('mousemove', onMove)
@@ -286,70 +125,43 @@ export default function LabelEditorOverlay({ template, zoom, onTemplateChange }:
         const y = Math.round(box.visualYMm * zoom * MM_TO_PX)
         const w = Math.max(20, Math.round(box.widthMm * zoom * MM_TO_PX))
         const h = Math.max(16, Math.round(box.heightMm * zoom * MM_TO_PX))
-        const fs = Math.max(7, Math.round(8 * zoom))
+        const selected = box.id === selectedFieldId
 
         return (
           <div
             key={box.id}
             onMouseDown={(e) => startMove(e, box.id)}
-            title={`${box.label}: ドラッグで移動 / 右下ハンドルでフォントサイズ変更`}
+            title={`${box.label}: クリックで編集対象選択 / ドラッグで移動 / 右下ハンドルで文字サイズ調整`}
             style={{
               position: 'absolute',
               left: x,
               top: y,
               width: w,
               height: h,
-              border: `1.5px dashed ${box.color}`,
+              border: `${selected ? 2 : 1.5}px dashed ${box.color}`,
+              background: selected ? `${box.color}20` : 'transparent',
               boxSizing: 'border-box',
               pointerEvents: 'auto',
               cursor: 'move',
               userSelect: 'none',
+              zIndex: selected ? 2 : 1,
             }}
           >
-            {/* コントロールバッジ (右上・半透明) */}
-            <div
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 1, position: 'absolute', top: 1, right: 1 }}
-              onMouseDown={(e) => e.stopPropagation()}
+            <span
+              style={{
+                position: 'absolute',
+                left: 1,
+                top: 1,
+                fontSize: Math.max(9, Math.round(10 * zoom)),
+                background: `${box.color}d9`,
+                color: '#fff',
+                borderRadius: 2,
+                padding: '0 4px',
+                lineHeight: 1.3,
+              }}
             >
-              {/* フォントサイズ行 */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <button
-                  onClick={(e) => { e.stopPropagation(); onTemplateChange(applyFontDelta(template, box.id, -0.5)) }}
-                  style={{ fontSize: fs, padding: '0 2px', cursor: 'pointer', background: `${box.color}cc`, border: 'none', color: '#fff', borderRadius: 2, lineHeight: 1 }}
-                >−</button>
-                <span style={{ fontSize: fs, minWidth: 24, textAlign: 'center', background: `${box.color}cc`, color: '#fff', borderRadius: 2, padding: '0 2px', lineHeight: 1 }}>{box.fontPt}pt</span>
-                <button
-                  onClick={(e) => { e.stopPropagation(); onTemplateChange(applyFontDelta(template, box.id, +0.5)) }}
-                  style={{ fontSize: fs, padding: '0 2px', cursor: 'pointer', background: `${box.color}cc`, border: 'none', color: '#fff', borderRadius: 2, lineHeight: 1 }}
-                >＋</button>
-              </div>
-              {/* フォントスタイル行 */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {/* 太字トグル */}
-                <button
-                  onClick={(e) => { e.stopPropagation(); onTemplateChange(applyBold(template, box.id, !box.bold)) }}
-                  title="太字"
-                  style={{ fontSize: fs, padding: '0 3px', cursor: 'pointer', border: 'none', color: '#fff', borderRadius: 2, lineHeight: 1, fontWeight: 'bold',
-                    background: box.bold ? box.color : `${box.color}88` }}
-                >B</button>
-                {/* 明朝トグル */}
-                <button
-                  onClick={(e) => { e.stopPropagation(); onTemplateChange(applyFontFamily(template, box.id, 'serif')) }}
-                  title="明朝体"
-                  style={{ fontSize: fs, padding: '0 2px', cursor: 'pointer', border: 'none', color: '#fff', borderRadius: 2, lineHeight: 1,
-                    background: box.fontFamily === 'serif' ? box.color : `${box.color}88` }}
-                >明</button>
-                {/* ゴシックトグル */}
-                <button
-                  onClick={(e) => { e.stopPropagation(); onTemplateChange(applyFontFamily(template, box.id, 'sans-serif')) }}
-                  title="ゴシック体"
-                  style={{ fontSize: fs, padding: '0 2px', cursor: 'pointer', border: 'none', color: '#fff', borderRadius: 2, lineHeight: 1,
-                    background: box.fontFamily === 'sans-serif' ? box.color : `${box.color}88` }}
-                >ゴ</button>
-              </div>
-            </div>
-
-            {/* リサイズハンドル (右下) */}
+              {box.label}
+            </span>
             <div
               onMouseDown={(e) => startResize(e, box.id, box.fontPt)}
               title="ドラッグでフォントサイズ変更"
@@ -357,11 +169,11 @@ export default function LabelEditorOverlay({ template, zoom, onTemplateChange }:
                 position: 'absolute',
                 right: 0,
                 bottom: 0,
-                width: 10,
-                height: 10,
+                width: 12,
+                height: 12,
                 background: box.color,
                 cursor: 'nwse-resize',
-                opacity: 0.85,
+                opacity: 0.9,
               }}
             />
           </div>

--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -10,6 +10,13 @@ import WatermarkLayer from './WatermarkLayer'
 import QROverlay from './QROverlay'
 import { useLabelStore } from '../../stores/labelStore'
 import type { Contact, Template, Watermark, QRConfig } from '../../types'
+import {
+  applyBold,
+  applyFontDelta,
+  applyFontFamily,
+  buildEditableBoxes,
+  type EditableFieldId,
+} from './labelEditorTemplate'
 
 /** 1mm あたりのピクセル数 (96 dpi 基準) — LabelCanvas と同じ定数 */
 const MM_TO_PX = 96 / 25.4
@@ -88,6 +95,8 @@ export default function PreviewArea() {
 
   // グリッド表示フラグ (ローカル状態)
   const [showGrid, setShowGrid] = useState(false)
+  // フォント編集対象フィールド
+  const [selectedFieldId, setSelectedFieldId] = useState<EditableFieldId | null>(null)
 
   // ── 背景ドラッグ: 印刷位置補正オフセット ─────────────────────────────────
 
@@ -147,70 +156,176 @@ export default function PreviewArea() {
   // ツールバー表示: ドラッグ中はライブ値、それ以外はストアの値
   const displayOffset = dragLive ?? { x: layout.offsetX, y: layout.offsetY }
   const hasOffset = displayOffset.x !== 0 || displayOffset.y !== 0
+  const editableBoxes = buildEditableBoxes(template)
+  const selectedBox = editableBoxes.find((box) => box.id === selectedFieldId) ?? null
+
+  useEffect(() => {
+    if (editableBoxes.length === 0) {
+      if (selectedFieldId !== null) setSelectedFieldId(null)
+      return
+    }
+    if (selectedFieldId && editableBoxes.some((box) => box.id === selectedFieldId)) return
+    setSelectedFieldId(editableBoxes[0].id)
+  }, [editableBoxes, selectedFieldId])
+
+  function updateSelectedField(
+    updater: (tpl: Template, fieldId: EditableFieldId) => Template,
+  ) {
+    if (!selectedFieldId) return
+    handleTemplateChange(updater(template, selectedFieldId))
+  }
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-[#f0f0f0]">
       {/* ツールバー */}
-      <div className="flex items-center gap-3 px-4 py-2 bg-white border-b border-gray-200 shrink-0">
-        <span className="text-sm font-medium text-gray-700 mr-auto">
-          {template.name}
-          {selectedContacts.length > 0 && (
-            <span className="ml-2 text-xs text-gray-400">
-              {safeIndex + 1} / {selectedContacts.length} 件
-            </span>
+      <div className="bg-white border-b border-gray-200 shrink-0">
+        <div className="flex items-center gap-3 px-4 py-2">
+          <span className="text-sm font-medium text-gray-700 mr-auto">
+            {template.name}
+            {selectedContacts.length > 0 && (
+              <span className="ml-2 text-xs text-gray-400">
+                {safeIndex + 1} / {selectedContacts.length} 件
+              </span>
+            )}
+          </span>
+          {/* オフセット表示 */}
+          {currentContact && hasOffset && (
+            <div className="flex items-center gap-1 text-xs text-amber-600">
+              <span>
+                補正: X {displayOffset.x.toFixed(1)} / Y {displayOffset.y.toFixed(1)} mm
+              </span>
+              <button
+                onClick={resetOffset}
+                className="underline hover:text-amber-800"
+                title="補正を初期値に戻す"
+              >
+                リセット
+              </button>
+            </div>
           )}
-        </span>
-        {/* オフセット表示 */}
-        {currentContact && hasOffset && (
-          <div className="flex items-center gap-1 text-xs text-amber-600">
-            <span>
-              補正: X {displayOffset.x.toFixed(1)} / Y {displayOffset.y.toFixed(1)} mm
-            </span>
+          {/* グリッドトグル */}
+          <button
+            onClick={() => setShowGrid((v) => !v)}
+            className={`px-2 py-1 text-xs rounded border transition-colors ${
+              showGrid
+                ? 'bg-slate-600 text-white border-slate-600'
+                : 'border-gray-300 text-gray-600 hover:bg-gray-100'
+            }`}
+            title="グリッド表示切り替え (5mm)"
+          >
+            グリッド
+          </button>
+          {/* ズームコントロール */}
+          <div className="flex items-center gap-1">
             <button
-              onClick={resetOffset}
-              className="underline hover:text-amber-800"
-              title="補正を初期値に戻す"
+              onClick={zoomOut}
+              disabled={zoom <= ZOOM_MIN}
+              className="px-2 py-1 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
+              aria-label="ズームアウト"
             >
-              リセット
+              −
+            </button>
+            <button
+              onClick={zoomReset}
+              className="px-3 py-1 text-xs rounded border border-gray-300 hover:bg-gray-100 min-w-[52px] text-center"
+            >
+              {Math.round(zoom * 100)}%
+            </button>
+            <button
+              onClick={zoomIn}
+              disabled={zoom >= ZOOM_MAX}
+              className="px-2 py-1 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
+              aria-label="ズームイン"
+            >
+              ＋
             </button>
           </div>
-        )}
-        {/* グリッドトグル */}
-        <button
-          onClick={() => setShowGrid((v) => !v)}
-          className={`px-2 py-1 text-xs rounded border transition-colors ${
-            showGrid
-              ? 'bg-slate-600 text-white border-slate-600'
-              : 'border-gray-300 text-gray-600 hover:bg-gray-100'
-          }`}
-          title="グリッド表示切り替え (5mm)"
-        >
-          グリッド
-        </button>
-        {/* ズームコントロール */}
-        <div className="flex items-center gap-1">
-          <button
-            onClick={zoomOut}
-            disabled={zoom <= ZOOM_MIN}
-            className="px-2 py-1 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
-            aria-label="ズームアウト"
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-t border-gray-100 bg-gray-50">
+          <span className="text-xs font-medium text-gray-700">文字設定</span>
+          <select
+            value={selectedFieldId ?? ''}
+            onChange={(e) => setSelectedFieldId(e.target.value as EditableFieldId)}
+            disabled={!currentContact || editableBoxes.length === 0}
+            className="h-8 min-w-[140px] rounded border border-gray-300 bg-white px-2 text-xs text-gray-700 disabled:opacity-40"
           >
-            −
-          </button>
+            {editableBoxes.length === 0 && <option value="">編集項目なし</option>}
+            {editableBoxes.map((box) => (
+              <option key={box.id} value={box.id}>
+                {box.label}
+              </option>
+            ))}
+          </select>
+
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-gray-500">サイズ</span>
+            <button
+              onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, -0.5))}
+              disabled={!selectedBox}
+              className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
+              title="文字サイズを小さくする"
+            >
+              −
+            </button>
+            <span className="h-8 min-w-[60px] rounded border border-gray-300 bg-white px-2 text-xs text-gray-700 inline-flex items-center justify-center">
+              {selectedBox ? `${selectedBox.fontPt} pt` : '---'}
+            </span>
+            <button
+              onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, 0.5))}
+              disabled={!selectedBox}
+              className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
+              title="文字サイズを大きくする"
+            >
+              ＋
+            </button>
+          </div>
+
+          <div className="flex items-center rounded border border-gray-300 overflow-hidden">
+            <button
+              onClick={() => updateSelectedField((tpl, id) => applyFontFamily(tpl, id, 'serif'))}
+              disabled={!selectedBox}
+              className={`h-8 px-3 text-xs transition-colors ${
+                selectedBox?.fontFamily === 'serif'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white text-gray-700 hover:bg-gray-100'
+              } disabled:opacity-40`}
+              title="明朝体"
+            >
+              明朝
+            </button>
+            <button
+              onClick={() =>
+                updateSelectedField((tpl, id) => applyFontFamily(tpl, id, 'sans-serif'))
+              }
+              disabled={!selectedBox}
+              className={`h-8 px-3 text-xs border-l border-gray-300 transition-colors ${
+                selectedBox?.fontFamily === 'sans-serif'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white text-gray-700 hover:bg-gray-100'
+              } disabled:opacity-40`}
+              title="ゴシック体"
+            >
+              ゴシック
+            </button>
+          </div>
+
           <button
-            onClick={zoomReset}
-            className="px-3 py-1 text-xs rounded border border-gray-300 hover:bg-gray-100 min-w-[52px] text-center"
+            onClick={() => updateSelectedField((tpl, id) => applyBold(tpl, id, !selectedBox?.bold))}
+            disabled={!selectedBox}
+            className={`h-8 px-3 rounded border text-xs transition-colors ${
+              selectedBox?.bold
+                ? 'bg-slate-700 border-slate-700 text-white'
+                : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-100'
+            } disabled:opacity-40`}
+            title="太字切替"
           >
-            {Math.round(zoom * 100)}%
+            太字
           </button>
-          <button
-            onClick={zoomIn}
-            disabled={zoom >= ZOOM_MAX}
-            className="px-2 py-1 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
-            aria-label="ズームイン"
-          >
-            ＋
-          </button>
+
+          <span className="text-[11px] text-gray-500">
+            項目を選んでフォント調整。位置はプレビュー上でドラッグ。
+          </span>
         </div>
       </div>
 
@@ -250,6 +365,8 @@ export default function PreviewArea() {
               <LabelEditorOverlay
                 template={template}
                 zoom={zoom}
+                selectedFieldId={selectedFieldId}
+                onSelectField={setSelectedFieldId}
                 onTemplateChange={handleTemplateChange}
               />
             </div>

--- a/frontend/src/components/preview/labelEditorTemplate.ts
+++ b/frontend/src/components/preview/labelEditorTemplate.ts
@@ -1,0 +1,232 @@
+import type { Template } from '../../types'
+
+export type EditableFieldId =
+  | 'postalCode'
+  | 'recipientName'
+  | 'recipientAddr'
+  | 'senderName'
+  | 'senderAddr'
+
+export interface EditableBox {
+  id: EditableFieldId
+  label: string
+  visualXMm: number
+  visualYMm: number
+  widthMm: number
+  heightMm: number
+  fontPt: number
+  fontFamily: 'serif' | 'sans-serif'
+  bold: boolean
+  color: string
+}
+
+export function buildEditableBoxes(tpl: Template): EditableBox[] {
+  const isVertical = tpl.orientation === 'vertical'
+  const labelHeight = tpl.labelHeight
+  const labelWidth = tpl.labelWidth
+  const boxes: EditableBox[] = []
+
+  if (tpl.postalCode) {
+    const postal = tpl.postalCode
+    boxes.push({
+      id: 'postalCode',
+      label: '〒 郵便番号',
+      visualXMm: postal.x - postal.digitSpacing * 0.4,
+      visualYMm: postal.y,
+      widthMm: postal.digitSpacing * 8.5,
+      heightMm: (postal.fontSize / 2.835) * 1.8,
+      fontPt: postal.fontSize,
+      fontFamily: postal.fontFamily ?? 'sans-serif',
+      bold: postal.bold ?? false,
+      color: '#3b82f6',
+    })
+  }
+
+  const recipient = tpl.recipient
+  if (isVertical) {
+    const nameWidth = (recipient.nameFont / 2.835) * 2.5
+    boxes.push({
+      id: 'recipientName',
+      label: '宛名',
+      visualXMm: recipient.nameX - nameWidth,
+      visualYMm: recipient.nameY,
+      widthMm: nameWidth,
+      heightMm: Math.max(5, labelHeight - recipient.nameY - 2),
+      fontPt: recipient.nameFont,
+      fontFamily: recipient.nameFontFamily ?? 'serif',
+      bold: recipient.nameBold ?? false,
+      color: '#10b981',
+    })
+    const addressWidth = (recipient.addressFont / 2.835) * 2.5
+    boxes.push({
+      id: 'recipientAddr',
+      label: '住所',
+      visualXMm: recipient.addressX - addressWidth,
+      visualYMm: recipient.addressY,
+      widthMm: addressWidth,
+      heightMm: Math.max(5, labelHeight - recipient.addressY - 2),
+      fontPt: recipient.addressFont,
+      fontFamily: recipient.addressFontFamily ?? 'serif',
+      bold: recipient.addressBold ?? false,
+      color: '#f59e0b',
+    })
+  } else {
+    boxes.push({
+      id: 'recipientName',
+      label: '宛名',
+      visualXMm: recipient.nameX,
+      visualYMm: recipient.nameY,
+      widthMm: Math.max(10, labelWidth - recipient.nameX - 2),
+      heightMm: (recipient.nameFont / 2.835) * 1.8,
+      fontPt: recipient.nameFont,
+      fontFamily: recipient.nameFontFamily ?? 'serif',
+      bold: recipient.nameBold ?? false,
+      color: '#10b981',
+    })
+    boxes.push({
+      id: 'recipientAddr',
+      label: '住所',
+      visualXMm: recipient.addressX,
+      visualYMm: recipient.addressY,
+      widthMm: Math.max(10, labelWidth - recipient.addressX - 2),
+      heightMm: (recipient.addressFont / 2.835) * 3.5,
+      fontPt: recipient.addressFont,
+      fontFamily: recipient.addressFontFamily ?? 'serif',
+      bold: recipient.addressBold ?? false,
+      color: '#f59e0b',
+    })
+  }
+
+  return boxes
+}
+
+export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm: number): Template {
+  const roundMm = (value: number) => Math.round(value * 10) / 10
+  switch (id) {
+    case 'postalCode':
+      if (!tpl.postalCode) return tpl
+      return {
+        ...tpl,
+        postalCode: {
+          ...tpl.postalCode,
+          x: roundMm(tpl.postalCode.x + dxMm),
+          y: roundMm(tpl.postalCode.y + dyMm),
+        },
+      }
+    case 'recipientName':
+      return {
+        ...tpl,
+        recipient: {
+          ...tpl.recipient,
+          nameX: roundMm(tpl.recipient.nameX + dxMm),
+          nameY: roundMm(tpl.recipient.nameY + dyMm),
+        },
+      }
+    case 'recipientAddr':
+      return {
+        ...tpl,
+        recipient: {
+          ...tpl.recipient,
+          addressX: roundMm(tpl.recipient.addressX + dxMm),
+          addressY: roundMm(tpl.recipient.addressY + dyMm),
+        },
+      }
+    case 'senderName':
+      return {
+        ...tpl,
+        sender: {
+          ...tpl.sender,
+          nameX: roundMm(tpl.sender.nameX + dxMm),
+          nameY: roundMm(tpl.sender.nameY + dyMm),
+        },
+      }
+    case 'senderAddr':
+      return {
+        ...tpl,
+        sender: {
+          ...tpl.sender,
+          addressX: roundMm(tpl.sender.addressX + dxMm),
+          addressY: roundMm(tpl.sender.addressY + dyMm),
+        },
+      }
+    default:
+      return tpl
+  }
+}
+
+export function applyFontDelta(tpl: Template, id: EditableFieldId, delta: number): Template {
+  const roundPt = (value: number) => Math.max(4, Math.round(value * 2) / 2)
+  switch (id) {
+    case 'postalCode':
+      if (!tpl.postalCode) return tpl
+      return {
+        ...tpl,
+        postalCode: {
+          ...tpl.postalCode,
+          fontSize: roundPt(tpl.postalCode.fontSize + delta),
+        },
+      }
+    case 'recipientName':
+      return {
+        ...tpl,
+        recipient: { ...tpl.recipient, nameFont: roundPt(tpl.recipient.nameFont + delta) },
+      }
+    case 'recipientAddr':
+      return {
+        ...tpl,
+        recipient: { ...tpl.recipient, addressFont: roundPt(tpl.recipient.addressFont + delta) },
+      }
+    case 'senderName':
+      return {
+        ...tpl,
+        sender: { ...tpl.sender, nameFont: roundPt(tpl.sender.nameFont + delta) },
+      }
+    case 'senderAddr':
+      return {
+        ...tpl,
+        sender: { ...tpl.sender, addressFont: roundPt(tpl.sender.addressFont + delta) },
+      }
+    default:
+      return tpl
+  }
+}
+
+export function applyFontFamily(
+  tpl: Template,
+  id: EditableFieldId,
+  family: 'serif' | 'sans-serif',
+): Template {
+  switch (id) {
+    case 'postalCode':
+      if (!tpl.postalCode) return tpl
+      return { ...tpl, postalCode: { ...tpl.postalCode, fontFamily: family } }
+    case 'recipientName':
+      return { ...tpl, recipient: { ...tpl.recipient, nameFontFamily: family } }
+    case 'recipientAddr':
+      return { ...tpl, recipient: { ...tpl.recipient, addressFontFamily: family } }
+    case 'senderName':
+      return { ...tpl, sender: { ...tpl.sender, nameFontFamily: family } }
+    case 'senderAddr':
+      return { ...tpl, sender: { ...tpl.sender, addressFontFamily: family } }
+    default:
+      return tpl
+  }
+}
+
+export function applyBold(tpl: Template, id: EditableFieldId, bold: boolean): Template {
+  switch (id) {
+    case 'postalCode':
+      if (!tpl.postalCode) return tpl
+      return { ...tpl, postalCode: { ...tpl.postalCode, bold } }
+    case 'recipientName':
+      return { ...tpl, recipient: { ...tpl.recipient, nameBold: bold } }
+    case 'recipientAddr':
+      return { ...tpl, recipient: { ...tpl.recipient, addressBold: bold } }
+    case 'senderName':
+      return { ...tpl, sender: { ...tpl.sender, nameBold: bold } }
+    case 'senderAddr':
+      return { ...tpl, sender: { ...tpl.sender, addressBold: bold } }
+    default:
+      return tpl
+  }
+}

--- a/frontend/src/components/preview/labelEditorTemplate.ts
+++ b/frontend/src/components/preview/labelEditorTemplate.ts
@@ -4,8 +4,6 @@ export type EditableFieldId =
   | 'postalCode'
   | 'recipientName'
   | 'recipientAddr'
-  | 'senderName'
-  | 'senderAddr'
 
 export interface EditableBox {
   id: EditableFieldId
@@ -131,24 +129,6 @@ export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm
           addressY: roundMm(tpl.recipient.addressY + dyMm),
         },
       }
-    case 'senderName':
-      return {
-        ...tpl,
-        sender: {
-          ...tpl.sender,
-          nameX: roundMm(tpl.sender.nameX + dxMm),
-          nameY: roundMm(tpl.sender.nameY + dyMm),
-        },
-      }
-    case 'senderAddr':
-      return {
-        ...tpl,
-        sender: {
-          ...tpl.sender,
-          addressX: roundMm(tpl.sender.addressX + dxMm),
-          addressY: roundMm(tpl.sender.addressY + dyMm),
-        },
-      }
     default:
       return tpl
   }
@@ -176,16 +156,6 @@ export function applyFontDelta(tpl: Template, id: EditableFieldId, delta: number
         ...tpl,
         recipient: { ...tpl.recipient, addressFont: roundPt(tpl.recipient.addressFont + delta) },
       }
-    case 'senderName':
-      return {
-        ...tpl,
-        sender: { ...tpl.sender, nameFont: roundPt(tpl.sender.nameFont + delta) },
-      }
-    case 'senderAddr':
-      return {
-        ...tpl,
-        sender: { ...tpl.sender, addressFont: roundPt(tpl.sender.addressFont + delta) },
-      }
     default:
       return tpl
   }
@@ -204,10 +174,6 @@ export function applyFontFamily(
       return { ...tpl, recipient: { ...tpl.recipient, nameFontFamily: family } }
     case 'recipientAddr':
       return { ...tpl, recipient: { ...tpl.recipient, addressFontFamily: family } }
-    case 'senderName':
-      return { ...tpl, sender: { ...tpl.sender, nameFontFamily: family } }
-    case 'senderAddr':
-      return { ...tpl, sender: { ...tpl.sender, addressFontFamily: family } }
     default:
       return tpl
   }
@@ -222,10 +188,6 @@ export function applyBold(tpl: Template, id: EditableFieldId, bold: boolean): Te
       return { ...tpl, recipient: { ...tpl.recipient, nameBold: bold } }
     case 'recipientAddr':
       return { ...tpl, recipient: { ...tpl.recipient, addressBold: bold } }
-    case 'senderName':
-      return { ...tpl, sender: { ...tpl.sender, nameBold: bold } }
-    case 'senderAddr':
-      return { ...tpl, sender: { ...tpl.sender, addressBold: bold } }
     default:
       return tpl
   }


### PR DESCRIPTION
## 概要
- ラベル上の小さいフォント操作ボタンを廃止し、上部に「文字設定」バーを追加
- 編集対象（郵便番号/宛名/住所）選択、文字サイズ、明朝/ゴシック、太字の操作を上部に集約
- オーバーレイは選択・移動・右下ハンドルでのサイズ調整に整理
- 編集ロジックを frontend/src/components/preview/labelEditorTemplate.ts に分離し、PreviewArea と Overlay で共通利用

## 変更ファイル
- frontend/src/components/preview/PreviewArea.tsx
- frontend/src/components/preview/LabelEditorOverlay.tsx
- frontend/src/components/preview/labelEditorTemplate.ts

## 動作確認
- npm run build
- npm run test:run

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オーバーレイ上のテキストフィールドを直接選択可能に（クリックで選択/切替）
  * ツールバーに選択フィールドのフォントサイズ、フォントファミリー、太字トグルを追加
  * 編集対象がない場合は選択が自動クリア、無効時はコントロールが無効化

* **UI改善**
  * 右上のコントロールバッジを廃止し、選択中フィールドは太い枠線・色付き背景・前面表示で強調
  * リサイズハンドルの外観とボックスタイトル表示を調整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->