### PR TITLE
ラベル編集画面のUX改善（Issue #53）

### DIFF
--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -14,7 +14,11 @@ import {
   applyBold,
   applyFontDelta,
   applyFontFamily,
+  applyMove,
   buildEditableBoxes,
+  getEditableFieldInspectorValue,
+  setEditableFieldFontPt,
+  setEditableFieldPosition,
   type EditableFieldId,
 } from './labelEditorTemplate'
 
@@ -24,6 +28,24 @@ const MM_TO_PX = 96 / 25.4
 const ZOOM_MIN = 0.5
 const ZOOM_MAX = 4.0
 const ZOOM_STEP = 0.25
+const KEYBOARD_FINE_STEP_MM = 0.1
+const KEYBOARD_COARSE_STEP_MM = 1.0
+
+function isEditableInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  return (
+    target.isContentEditable ||
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT'
+  )
+}
+
+function parseInputNumber(rawValue: string): number | null {
+  const parsed = Number.parseFloat(rawValue)
+  return Number.isFinite(parsed) ? parsed : null
+}
 
 export default function PreviewArea() {
   const { contacts, selectedIds } = useContactStore(
@@ -158,6 +180,9 @@ export default function PreviewArea() {
   const hasOffset = displayOffset.x !== 0 || displayOffset.y !== 0
   const editableBoxes = buildEditableBoxes(template)
   const selectedBox = editableBoxes.find((box) => box.id === selectedFieldId) ?? null
+  const selectedInspector = selectedFieldId
+    ? getEditableFieldInspectorValue(template, selectedFieldId)
+    : null
 
   useEffect(() => {
     if (editableBoxes.length === 0) {
@@ -174,6 +199,57 @@ export default function PreviewArea() {
     if (!selectedFieldId) return
     handleTemplateChange(updater(template, selectedFieldId))
   }
+
+  function updateSelectedPositionFromInput(axis: 'x' | 'y', rawValue: string) {
+    if (!selectedFieldId || !selectedInspector) return
+    const parsed = parseInputNumber(rawValue)
+    if (parsed === null) return
+
+    const nextX = axis === 'x' ? parsed : selectedInspector.xMm
+    const nextY = axis === 'y' ? parsed : selectedInspector.yMm
+    handleTemplateChange(setEditableFieldPosition(template, selectedFieldId, nextX, nextY))
+  }
+
+  function updateSelectedFontFromInput(rawValue: string) {
+    if (!selectedFieldId) return
+    const parsed = parseInputNumber(rawValue)
+    if (parsed === null) return
+    handleTemplateChange(setEditableFieldFontPt(template, selectedFieldId, parsed))
+  }
+
+  useEffect(() => {
+    if (!currentContact || !selectedFieldId) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isEditableInputTarget(event.target)) return
+      const step = event.shiftKey ? KEYBOARD_COARSE_STEP_MM : KEYBOARD_FINE_STEP_MM
+      let dx = 0
+      let dy = 0
+
+      switch (event.key) {
+        case 'ArrowLeft':
+          dx = -step
+          break
+        case 'ArrowRight':
+          dx = step
+          break
+        case 'ArrowUp':
+          dy = -step
+          break
+        case 'ArrowDown':
+          dy = step
+          break
+        default:
+          return
+      }
+
+      event.preventDefault()
+      handleTemplateChange(applyMove(template, selectedFieldId, dx, dy))
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [currentContact, selectedFieldId, template])
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-[#f0f0f0]">
@@ -244,41 +320,91 @@ export default function PreviewArea() {
 
         <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-t border-gray-100 bg-gray-50">
           <span className="text-xs font-medium text-gray-700">文字設定</span>
-          <select
-            value={selectedFieldId ?? ''}
-            onChange={(e) => setSelectedFieldId(e.target.value as EditableFieldId)}
-            disabled={!currentContact || editableBoxes.length === 0}
-            className="h-8 min-w-[140px] rounded border border-gray-300 bg-white px-2 text-xs text-gray-700 disabled:opacity-40"
-          >
-            {editableBoxes.length === 0 && <option value="">編集項目なし</option>}
-            {editableBoxes.map((box) => (
-              <option key={box.id} value={box.id}>
-                {box.label}
-              </option>
-            ))}
-          </select>
+
+          <div className="flex flex-wrap items-center gap-1 rounded border border-gray-300 bg-white p-1">
+            {editableBoxes.length === 0 && (
+              <span className="px-2 text-xs text-gray-500">編集項目なし</span>
+            )}
+            {editableBoxes.map((box) => {
+              const selected = box.id === selectedFieldId
+              return (
+                <button
+                  key={box.id}
+                  onClick={() => setSelectedFieldId(box.id)}
+                  disabled={!currentContact}
+                  className={`h-7 rounded px-2 text-xs border transition-colors inline-flex items-center gap-1.5 ${
+                    selected
+                      ? 'bg-slate-700 text-white border-slate-700'
+                      : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100'
+                  } disabled:opacity-40`}
+                  title={`${box.label} を編集`}
+                >
+                  <span
+                    className="inline-block h-2 w-2 rounded-full"
+                    style={{ backgroundColor: box.color }}
+                  />
+                  {box.label}
+                </button>
+              )
+            })}
+          </div>
 
           <div className="flex items-center gap-1">
             <span className="text-xs text-gray-500">サイズ</span>
             <button
               onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, -0.5))}
-              disabled={!selectedBox}
+              disabled={!selectedInspector}
               className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
               title="文字サイズを小さくする"
             >
               −
             </button>
-            <span className="h-8 min-w-[60px] rounded border border-gray-300 bg-white px-2 text-xs text-gray-700 inline-flex items-center justify-center">
-              {selectedBox ? `${selectedBox.fontPt} pt` : '---'}
-            </span>
+            <input
+              type="number"
+              step={0.5}
+              value={selectedInspector ? selectedInspector.fontPt.toFixed(1) : ''}
+              onChange={(e) => updateSelectedFontFromInput(e.target.value)}
+              disabled={!selectedInspector}
+              className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
+              title="フォントサイズ (pt)"
+            />
+            <span className="text-xs text-gray-500">pt</span>
             <button
               onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, 0.5))}
-              disabled={!selectedBox}
+              disabled={!selectedInspector}
               className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
               title="文字サイズを大きくする"
             >
               ＋
             </button>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-gray-500">X</span>
+            <input
+              type="number"
+              step={0.1}
+              value={selectedInspector ? selectedInspector.xMm.toFixed(1) : ''}
+              onChange={(e) => updateSelectedPositionFromInput('x', e.target.value)}
+              disabled={!selectedInspector}
+              className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
+              title="X 座標 (mm)"
+            />
+            <span className="text-xs text-gray-500">mm</span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-gray-500">Y</span>
+            <input
+              type="number"
+              step={0.1}
+              value={selectedInspector ? selectedInspector.yMm.toFixed(1) : ''}
+              onChange={(e) => updateSelectedPositionFromInput('y', e.target.value)}
+              disabled={!selectedInspector}
+              className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
+              title="Y 座標 (mm)"
+            />
+            <span className="text-xs text-gray-500">mm</span>
           </div>
 
           <div className="flex items-center rounded border border-gray-300 overflow-hidden">
@@ -324,7 +450,7 @@ export default function PreviewArea() {
           </button>
 
           <span className="text-[11px] text-gray-500">
-            項目を選んでフォント調整。位置はプレビュー上でドラッグ。
+            矢印キーで 0.1mm、Shift+矢印で 1.0mm 移動。ドラッグと数値は同期。
           </span>
         </div>
       </div>

--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -119,6 +119,11 @@ export default function PreviewArea() {
   const [showGrid, setShowGrid] = useState(false)
   // フォント編集対象フィールド
   const [selectedFieldId, setSelectedFieldId] = useState<EditableFieldId | null>(null)
+  const latestTemplateRef = useRef(template)
+
+  useEffect(() => {
+    latestTemplateRef.current = template
+  }, [template])
 
   // ── 背景ドラッグ: 印刷位置補正オフセット ─────────────────────────────────
 
@@ -244,12 +249,12 @@ export default function PreviewArea() {
       }
 
       event.preventDefault()
-      handleTemplateChange(applyMove(template, selectedFieldId, dx, dy))
+      handleTemplateChange(applyMove(latestTemplateRef.current, selectedFieldId, dx, dy))
     }
 
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [currentContact, selectedFieldId, template])
+  }, [currentContact, selectedFieldId])
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-[#f0f0f0]">

--- a/frontend/src/components/preview/labelEditorTemplate.test.ts
+++ b/frontend/src/components/preview/labelEditorTemplate.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_TEMPLATE } from './LabelCanvas'
+import {
+  applyFontDelta,
+  applyMove,
+  getEditableFieldInspectorValue,
+  setEditableFieldFontPt,
+  setEditableFieldPosition,
+} from './labelEditorTemplate'
+import type { Template } from '../../types'
+
+function cloneTemplate(base: Template = DEFAULT_TEMPLATE): Template {
+  return {
+    ...base,
+    recipient: { ...base.recipient },
+    sender: { ...base.sender },
+    postalCode: base.postalCode ? { ...base.postalCode } : undefined,
+  }
+}
+
+describe('labelEditorTemplate inspector helpers', () => {
+  it('選択中フィールドの値を取得できる', () => {
+    const tpl = cloneTemplate()
+    const inspector = getEditableFieldInspectorValue(tpl, 'recipientName')
+
+    expect(inspector).not.toBeNull()
+    expect(inspector?.xMm).toBe(tpl.recipient.nameX)
+    expect(inspector?.yMm).toBe(tpl.recipient.nameY)
+    expect(inspector?.fontPt).toBe(tpl.recipient.nameFont)
+  })
+
+  it('座標を 0.1mm 刻みで直接更新できる', () => {
+    const tpl = cloneTemplate()
+    const updated = setEditableFieldPosition(tpl, 'recipientAddr', 12.34, 56.78)
+
+    expect(updated.recipient.addressX).toBe(12.3)
+    expect(updated.recipient.addressY).toBe(56.8)
+  })
+
+  it('フォントサイズを 0.5pt 刻みで更新し、最小値を下回らない', () => {
+    const tpl = cloneTemplate()
+    const rounded = setEditableFieldFontPt(tpl, 'recipientName', 10.26)
+    const clamped = setEditableFieldFontPt(tpl, 'recipientName', 2)
+
+    expect(rounded.recipient.nameFont).toBe(10.5)
+    expect(clamped.recipient.nameFont).toBe(4)
+  })
+
+  it('applyMove は既存座標に差分を適用する', () => {
+    const tpl = cloneTemplate()
+    const updated = applyMove(tpl, 'postalCode', 0.26, -0.24)
+
+    expect(updated.postalCode?.x).toBe(36.3)
+    expect(updated.postalCode?.y).toBe(4.3)
+  })
+
+  it('applyFontDelta は差分でフォント更新する', () => {
+    const tpl = cloneTemplate()
+    const updated = applyFontDelta(tpl, 'postalCode', -6.2)
+
+    expect(updated.postalCode?.fontSize).toBe(4)
+  })
+
+  it('郵便番号設定がない場合は postalCode の編集を無視する', () => {
+    const tpl = cloneTemplate({ ...DEFAULT_TEMPLATE, postalCode: undefined })
+
+    expect(getEditableFieldInspectorValue(tpl, 'postalCode')).toBeNull()
+    expect(setEditableFieldPosition(tpl, 'postalCode', 1, 1)).toEqual(tpl)
+    expect(setEditableFieldFontPt(tpl, 'postalCode', 9)).toEqual(tpl)
+  })
+})

--- a/frontend/src/components/preview/labelEditorTemplate.ts
+++ b/frontend/src/components/preview/labelEditorTemplate.ts
@@ -18,6 +18,15 @@ export interface EditableBox {
   color: string
 }
 
+export interface EditableFieldInspectorValue {
+  xMm: number
+  yMm: number
+  fontPt: number
+}
+
+const roundMm = (value: number) => Math.round(value * 10) / 10
+const roundPt = (value: number) => Math.max(4, Math.round(value * 2) / 2)
+
 export function buildEditableBoxes(tpl: Template): EditableBox[] {
   const isVertical = tpl.orientation === 'vertical'
   const labelHeight = tpl.labelHeight
@@ -98,8 +107,44 @@ export function buildEditableBoxes(tpl: Template): EditableBox[] {
   return boxes
 }
 
-export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm: number): Template {
-  const roundMm = (value: number) => Math.round(value * 10) / 10
+export function getEditableFieldInspectorValue(
+  tpl: Template,
+  id: EditableFieldId,
+): EditableFieldInspectorValue | null {
+  switch (id) {
+    case 'postalCode':
+      if (!tpl.postalCode) return null
+      return {
+        xMm: tpl.postalCode.x,
+        yMm: tpl.postalCode.y,
+        fontPt: tpl.postalCode.fontSize,
+      }
+    case 'recipientName':
+      return {
+        xMm: tpl.recipient.nameX,
+        yMm: tpl.recipient.nameY,
+        fontPt: tpl.recipient.nameFont,
+      }
+    case 'recipientAddr':
+      return {
+        xMm: tpl.recipient.addressX,
+        yMm: tpl.recipient.addressY,
+        fontPt: tpl.recipient.addressFont,
+      }
+    default:
+      return null
+  }
+}
+
+export function setEditableFieldPosition(
+  tpl: Template,
+  id: EditableFieldId,
+  xMm: number,
+  yMm: number,
+): Template {
+  const roundedX = roundMm(xMm)
+  const roundedY = roundMm(yMm)
+
   switch (id) {
     case 'postalCode':
       if (!tpl.postalCode) return tpl
@@ -107,8 +152,8 @@ export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm
         ...tpl,
         postalCode: {
           ...tpl.postalCode,
-          x: roundMm(tpl.postalCode.x + dxMm),
-          y: roundMm(tpl.postalCode.y + dyMm),
+          x: roundedX,
+          y: roundedY,
         },
       }
     case 'recipientName':
@@ -116,8 +161,8 @@ export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm
         ...tpl,
         recipient: {
           ...tpl.recipient,
-          nameX: roundMm(tpl.recipient.nameX + dxMm),
-          nameY: roundMm(tpl.recipient.nameY + dyMm),
+          nameX: roundedX,
+          nameY: roundedY,
         },
       }
     case 'recipientAddr':
@@ -125,8 +170,8 @@ export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm
         ...tpl,
         recipient: {
           ...tpl.recipient,
-          addressX: roundMm(tpl.recipient.addressX + dxMm),
-          addressY: roundMm(tpl.recipient.addressY + dyMm),
+          addressX: roundedX,
+          addressY: roundedY,
         },
       }
     default:
@@ -134,8 +179,13 @@ export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm
   }
 }
 
-export function applyFontDelta(tpl: Template, id: EditableFieldId, delta: number): Template {
-  const roundPt = (value: number) => Math.max(4, Math.round(value * 2) / 2)
+export function setEditableFieldFontPt(
+  tpl: Template,
+  id: EditableFieldId,
+  fontPt: number,
+): Template {
+  const roundedFont = roundPt(fontPt)
+
   switch (id) {
     case 'postalCode':
       if (!tpl.postalCode) return tpl
@@ -143,22 +193,34 @@ export function applyFontDelta(tpl: Template, id: EditableFieldId, delta: number
         ...tpl,
         postalCode: {
           ...tpl.postalCode,
-          fontSize: roundPt(tpl.postalCode.fontSize + delta),
+          fontSize: roundedFont,
         },
       }
     case 'recipientName':
       return {
         ...tpl,
-        recipient: { ...tpl.recipient, nameFont: roundPt(tpl.recipient.nameFont + delta) },
+        recipient: { ...tpl.recipient, nameFont: roundedFont },
       }
     case 'recipientAddr':
       return {
         ...tpl,
-        recipient: { ...tpl.recipient, addressFont: roundPt(tpl.recipient.addressFont + delta) },
+        recipient: { ...tpl.recipient, addressFont: roundedFont },
       }
     default:
       return tpl
   }
+}
+
+export function applyMove(tpl: Template, id: EditableFieldId, dxMm: number, dyMm: number): Template {
+  const current = getEditableFieldInspectorValue(tpl, id)
+  if (!current) return tpl
+  return setEditableFieldPosition(tpl, id, current.xMm + dxMm, current.yMm + dyMm)
+}
+
+export function applyFontDelta(tpl: Template, id: EditableFieldId, delta: number): Template {
+  const current = getEditableFieldInspectorValue(tpl, id)
+  if (!current) return tpl
+  return setEditableFieldFontPt(tpl, id, current.fontPt + delta)
 }
 
 export function applyFontFamily(


### PR DESCRIPTION
## 概要\n- 編集対象（郵便番号/宛名/住所）を常時表示し、選択中項目を強調表示\n- 文字サイズを数値入力（0.5pt刻み）で直接編集できるように変更\n- X/Y 座標を数値入力（0.1mm刻み）で直接編集できるように変更\n- 矢印キー（0.1mm）と Shift+矢印（1.0mm）で微調整を追加\n- ドラッグ操作と数値入力の双方向同期を維持\n\n## テスト\n- npm run test:run\n- npm run build\n- go test ./...\n\nCloses #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * キーボードナビゲーション対応：矢印キーでフィールドの位置を移動可能
  * フォントサイズの数値入力に対応
  * X/Y座標を数値入力（mm単位）で直接編集可能に
  * フィールド選択UIを改善：インラインボタン形式に変更

* **テスト**
  * 数値編集機能のテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->