### PR TITLE
feat: 宛先氏名の自動レイアウト調整（長文時の自動縮小）

### DIFF
--- a/frontend/src/lib/labelRenderer.ts
+++ b/frontend/src/lib/labelRenderer.ts
@@ -1,9 +1,18 @@
 import type { Contact, Template } from '../types'
 import { drawVerticalBlock } from './verticalText'
+import { fitHorizontalNameFontPx, fitVerticalNameFontPx } from './nameAutoLayout'
 
 /** 96dpi 時の 1mm あたりピクセル数 */
 export const MM_TO_PX_AT_96_DPI = 96 / 25.4
 const PT_TO_MM = 25.4 / 72
+const NAME_LAYOUT_PADDING_MM = 2
+
+function measureTextWidth(ctx: CanvasRenderingContext2D, text: string, fallbackFontPx: number): number {
+  if (typeof ctx.measureText === 'function') {
+    return ctx.measureText(text).width
+  }
+  return [...text].length * fallbackFontPx
+}
 
 /** 郵便番号を "NNN-NNNN" 形式に整形する */
 export function formatPostalCode(raw: string): string {
@@ -110,9 +119,13 @@ function renderVerticalLabel(
 ): void {
   {
     const rc = tpl.recipient
-    const nameFontPx = ptToPx(rc.nameFont, pxPerMm)
+    const baseNameFontPx = ptToPx(rc.nameFont, pxPerMm)
     const name = `${contact.familyName}${contact.givenName}`
     const honorific = contact.honorific || '様'
+    const nameLines = [honorific, name]
+    const maxChars = nameLines.reduce((max, line) => Math.max(max, [...line].length), 0)
+    const availableHeightPx = mmToPx(Math.max(5, tpl.labelHeight - rc.nameY - NAME_LAYOUT_PADDING_MM), pxPerMm)
+    const nameFontPx = fitVerticalNameFontPx(baseNameFontPx, maxChars, availableHeightPx)
 
     ctx.fillStyle = '#111827'
     const nameWeight = rc.nameBold ? 'bold' : 'normal'
@@ -120,7 +133,7 @@ function renderVerticalLabel(
 
     drawVerticalBlock({
       ctx,
-      lines: [honorific, name],
+      lines: nameLines,
       rightX: mmToPx(rc.nameX, pxPerMm),
       topY: mmToPx(rc.nameY, pxPerMm),
       fontSize: nameFontPx,
@@ -157,12 +170,18 @@ function renderHorizontalLabel(
 ): void {
   {
     const rc = tpl.recipient
-    const nameFontPx = ptToPx(rc.nameFont, pxPerMm)
+    const baseNameFontPx = ptToPx(rc.nameFont, pxPerMm)
     const honorific = contact.honorific || '様'
     const fullName = `${contact.familyName}${contact.givenName}　${honorific}`
+    const fontFamily = resolveFontFamily(rc.nameFontFamily)
+    const nameWeight = rc.nameBold ? 'bold' : 'normal'
+    const availableWidthPx = mmToPx(Math.max(10, tpl.labelWidth - rc.nameX - NAME_LAYOUT_PADDING_MM), pxPerMm)
 
     ctx.fillStyle = '#111827'
-    ctx.font = `${rc.nameBold ? 'bold' : 'normal'} ${nameFontPx}px ${resolveFontFamily(rc.nameFontFamily)}`
+    ctx.font = `${nameWeight} ${baseNameFontPx}px ${fontFamily}`
+    const measuredWidth = measureTextWidth(ctx, fullName, baseNameFontPx)
+    const nameFontPx = fitHorizontalNameFontPx(baseNameFontPx, measuredWidth, availableWidthPx)
+    ctx.font = `${nameWeight} ${nameFontPx}px ${fontFamily}`
     ctx.textAlign = 'left'
     ctx.textBaseline = 'top'
     ctx.fillText(fullName, mmToPx(rc.nameX, pxPerMm), mmToPx(rc.nameY, pxPerMm))

--- a/frontend/src/lib/nameAutoLayout.test.ts
+++ b/frontend/src/lib/nameAutoLayout.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { fitHorizontalNameFontPx, fitVerticalNameFontPx } from './nameAutoLayout'
+
+describe('fitHorizontalNameFontPx', () => {
+  it('収まる場合は元サイズを維持する', () => {
+    expect(fitHorizontalNameFontPx(40, 180, 200)).toBe(40)
+  })
+
+  it('はみ出す場合は縮小する', () => {
+    const fitted = fitHorizontalNameFontPx(40, 240, 180)
+    expect(fitted).toBeLessThan(40)
+    expect(fitted).toBeCloseTo(30)
+  })
+
+  it('縮小下限を下回らない', () => {
+    const fitted = fitHorizontalNameFontPx(40, 1000, 100)
+    expect(fitted).toBeCloseTo(24) // 40 * 0.6
+  })
+})
+
+describe('fitVerticalNameFontPx', () => {
+  it('収まる場合は元サイズを維持する', () => {
+    expect(fitVerticalNameFontPx(40, 4, 200)).toBe(40)
+  })
+
+  it('文字数が多い場合は縮小する', () => {
+    const fitted = fitVerticalNameFontPx(40, 10, 300)
+    expect(fitted).toBeLessThan(40)
+  })
+
+  it('縦方向でも縮小下限を下回らない', () => {
+    const fitted = fitVerticalNameFontPx(40, 30, 100)
+    expect(fitted).toBeCloseTo(24) // 40 * 0.6
+  })
+})
+

--- a/frontend/src/lib/nameAutoLayout.ts
+++ b/frontend/src/lib/nameAutoLayout.ts
@@ -1,0 +1,36 @@
+const NAME_AUTO_MIN_SCALE = 0.6
+const VERTICAL_CHAR_HEIGHT_SCALE = 1.05
+
+/** 長い氏名が横幅を超える場合にフォントを自動縮小する */
+export function fitHorizontalNameFontPx(
+  baseFontPx: number,
+  measuredWidthPx: number,
+  availableWidthPx: number,
+): number {
+  if (baseFontPx <= 0 || measuredWidthPx <= 0 || availableWidthPx <= 0) {
+    return baseFontPx
+  }
+  if (measuredWidthPx <= availableWidthPx) {
+    return baseFontPx
+  }
+  const scaled = baseFontPx * (availableWidthPx / measuredWidthPx)
+  return Math.max(baseFontPx * NAME_AUTO_MIN_SCALE, scaled)
+}
+
+/** 長い氏名が縦方向に収まらない場合にフォントを自動縮小する */
+export function fitVerticalNameFontPx(
+  baseFontPx: number,
+  maxChars: number,
+  availableHeightPx: number,
+): number {
+  if (baseFontPx <= 0 || maxChars <= 0 || availableHeightPx <= 0) {
+    return baseFontPx
+  }
+  const requiredHeight = baseFontPx * VERTICAL_CHAR_HEIGHT_SCALE * maxChars
+  if (requiredHeight <= availableHeightPx) {
+    return baseFontPx
+  }
+  const scaled = availableHeightPx / (VERTICAL_CHAR_HEIGHT_SCALE * maxChars)
+  return Math.max(baseFontPx * NAME_AUTO_MIN_SCALE, scaled)
+}
+

--- a/internal/infrastructure/pdf/label_pdf.go
+++ b/internal/infrastructure/pdf/label_pdf.go
@@ -300,6 +300,12 @@ var japaneseCoverageChars = []rune{
 // must be converted.
 const ptToMm = 25.4 / 72.0
 
+const (
+	nameAutoMinScale       = 0.6
+	verticalCharHeightRate = 1.05
+	nameLayoutPaddingMm    = 2.0
+)
+
 // japaneseCmapScore returns the number of japaneseCoverageChars mapped in the
 // font's Unicode BMP cmap (Format 4). A higher score indicates better Japanese
 // character coverage.
@@ -797,11 +803,16 @@ func drawLabel(
 
 	if tmpl.Orientation == "vertical" {
 		// 縦書き: プレビュー drawVerticalBlock と同じ右端基準・列幅
-		setFont(rec.NameFont, rec.NameFontFamily)
-		nameFontMm := rec.NameFont * ptToMm
+		nameCols := []string{honorific, contact.FamilyName + contact.GivenName}
+		availableNameH := tmpl.LabelHeight - rec.NameY - nameLayoutPaddingMm
+		if availableNameH < 5 {
+			availableNameH = 5
+		}
+		nameFontPt := fitVerticalNameFontPt(rec.NameFont, maxRunes(nameCols), availableNameH)
+		setFont(nameFontPt, rec.NameFontFamily)
+		nameFontMm := nameFontPt * ptToMm
 		// プレビューと同じ列順: [敬称(最右列), 氏名]
-		drawVerticalBlockPDF(pdf, []string{honorific, contact.FamilyName + contact.GivenName},
-			ox+rec.NameX, oy+rec.NameY, nameFontMm)
+		drawVerticalBlockPDF(pdf, nameCols, ox+rec.NameX, oy+rec.NameY, nameFontMm)
 
 		setFont(rec.AddressFont, rec.AddressFontFamily)
 		addrFontMm := rec.AddressFont * ptToMm
@@ -813,8 +824,15 @@ func drawLabel(
 		drawVerticalBlockPDF(pdf, kanjiAddrLines, ox+rec.AddressX, oy+rec.AddressY, addrFontMm)
 	} else {
 		// 横書き: 行高をプレビューと同じ pt→mm 変換で計算
+		availableNameW := tmpl.LabelWidth - rec.NameX - nameLayoutPaddingMm
+		if availableNameW < 10 {
+			availableNameW = 10
+		}
 		setFont(rec.NameFont, rec.NameFontFamily)
-		nameFontMm := rec.NameFont * ptToMm
+		measuredNameW := pdf.GetStringWidth(fullName)
+		nameFontPt := fitHorizontalNameFontPt(rec.NameFont, measuredNameW, availableNameW)
+		setFont(nameFontPt, rec.NameFontFamily)
+		nameFontMm := nameFontPt * ptToMm
 		nameLineH := nameFontMm * 1.4 // プレビューの nameFont は単一行なので余裕を持たせる
 		for i, line := range nameLines {
 			pdf.SetXY(ox+rec.NameX, oy+rec.NameY+float64(i)*nameLineH)
@@ -833,6 +851,48 @@ func drawLabel(
 	// TODO: 差出人描画はアプリプレビュー (LabelCanvas) が対応次第ここに実装する。
 	// 現時点では LabelCanvas が差出人を描画しないため、PDF でも非表示にしてプレビューと一致させる。
 	_ = sender
+}
+
+func maxRunes(lines []string) int {
+	maxLen := 0
+	for _, line := range lines {
+		n := len([]rune(line))
+		if n > maxLen {
+			maxLen = n
+		}
+	}
+	return maxLen
+}
+
+func fitHorizontalNameFontPt(baseFontPt, measuredWidthMm, availableWidthMm float64) float64 {
+	if baseFontPt <= 0 || measuredWidthMm <= 0 || availableWidthMm <= 0 {
+		return baseFontPt
+	}
+	if measuredWidthMm <= availableWidthMm {
+		return baseFontPt
+	}
+	scaled := baseFontPt * (availableWidthMm / measuredWidthMm)
+	minFont := baseFontPt * nameAutoMinScale
+	if scaled < minFont {
+		return minFont
+	}
+	return scaled
+}
+
+func fitVerticalNameFontPt(baseFontPt float64, maxChars int, availableHeightMm float64) float64 {
+	if baseFontPt <= 0 || maxChars <= 0 || availableHeightMm <= 0 {
+		return baseFontPt
+	}
+	required := baseFontPt * ptToMm * verticalCharHeightRate * float64(maxChars)
+	if required <= availableHeightMm {
+		return baseFontPt
+	}
+	scaledPt := availableHeightMm / (ptToMm * verticalCharHeightRate * float64(maxChars))
+	minFont := baseFontPt * nameAutoMinScale
+	if scaledPt < minFont {
+		return minFont
+	}
+	return scaledPt
 }
 
 // drawVerticalBlockPDF renders lines of text as vertical columns, matching the

--- a/internal/infrastructure/pdf/name_auto_layout_test.go
+++ b/internal/infrastructure/pdf/name_auto_layout_test.go
@@ -1,0 +1,60 @@
+package pdf
+
+import "testing"
+
+func almostEqualFont(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < eps
+}
+
+func TestFitHorizontalNameFontPt(t *testing.T) {
+	t.Run("fits in width keeps base size", func(t *testing.T) {
+		got := fitHorizontalNameFontPt(12, 40, 50)
+		if got != 12 {
+			t.Fatalf("got %v, want 12", got)
+		}
+	})
+
+	t.Run("overflow shrinks font", func(t *testing.T) {
+		got := fitHorizontalNameFontPt(12, 60, 45)
+		if !(got < 12) {
+			t.Fatalf("got %v, want < 12", got)
+		}
+	})
+
+	t.Run("clamps to minimum scale", func(t *testing.T) {
+		got := fitHorizontalNameFontPt(12, 200, 30)
+		want := 12 * nameAutoMinScale
+		if !almostEqualFont(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestFitVerticalNameFontPt(t *testing.T) {
+	t.Run("fits in height keeps base size", func(t *testing.T) {
+		got := fitVerticalNameFontPt(12, 4, 30)
+		if got != 12 {
+			t.Fatalf("got %v, want 12", got)
+		}
+	})
+
+	t.Run("overflow shrinks font", func(t *testing.T) {
+		got := fitVerticalNameFontPt(12, 12, 30)
+		if !(got < 12) {
+			t.Fatalf("got %v, want < 12", got)
+		}
+	})
+
+	t.Run("clamps to minimum scale", func(t *testing.T) {
+		got := fitVerticalNameFontPt(12, 100, 10)
+		want := 12 * nameAutoMinScale
+		if !almostEqualFont(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## 概要
- 宛先氏名が長い場合に、横書き・縦書きで自動フォント縮小してレイアウト崩れを抑える機能を追加
- プレビュー描画と PDF フォールバック描画の両方に同等ロジックを適用

## 変更内容
- `frontend/src/lib/nameAutoLayout.ts`
  - 横書き/縦書きの氏名フォント自動調整関数を追加
- `frontend/src/lib/labelRenderer.ts`
  - 横書き: テキスト幅が利用可能幅を超える場合に自動縮小
  - 縦書き: 文字数に対して利用可能高さを超える場合に自動縮小
  - テスト環境向けに `measureText` 非対応時のフォールバックを追加
- `internal/infrastructure/pdf/label_pdf.go`
  - PDF 側にも同等の自動縮小ロジックを実装（横/縦）

## テスト
- `cd frontend && npx vitest run src/lib/nameAutoLayout.test.ts src/lib/labelSnapshot.parity.test.ts`
- `go test ./internal/infrastructure/pdf/...`

Refs: #61
