### PR TITLE
縦書き時の敬称を氏名の下に配置する

### DIFF
--- a/frontend/src/lib/labelRenderer.test.ts
+++ b/frontend/src/lib/labelRenderer.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Contact, Template } from '../types'
+
+vi.mock('./verticalText', () => ({
+  drawVerticalBlock: vi.fn(),
+}))
+
+import { renderLabelTextLayer } from './labelRenderer'
+import { drawVerticalBlock } from './verticalText'
+
+type MockContext = Pick<
+  CanvasRenderingContext2D,
+  'fillStyle' | 'strokeStyle' | 'lineWidth' | 'font' | 'textAlign' | 'textBaseline' | 'fillRect' | 'strokeRect' | 'fillText'
+>
+
+function createMockContext(): MockContext {
+  return {
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'left',
+    textBaseline: 'top',
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+  }
+}
+
+const baseContact: Contact = {
+  id: 'c1',
+  familyName: '山田',
+  givenName: '太郎',
+  familyNameKana: '',
+  givenNameKana: '',
+  honorific: '様',
+  postalCode: '',
+  prefecture: '東京都',
+  city: '千代田区',
+  street: '1-2-3',
+  building: 'テストビル',
+  company: '',
+  department: '',
+  notes: '',
+  createdAt: '',
+  updatedAt: '',
+}
+
+const baseTemplate: Template = {
+  id: 'tmpl',
+  name: 'test',
+  orientation: 'vertical',
+  labelWidth: 86.4,
+  labelHeight: 42.3,
+  recipient: {
+    nameX: 79,
+    nameY: 8,
+    nameFont: 13,
+    addressX: 69,
+    addressY: 8,
+    addressFont: 8.5,
+  },
+  sender: {
+    nameX: 16,
+    nameY: 24,
+    nameFont: 6.5,
+    addressX: 8,
+    addressY: 24,
+    addressFont: 5.5,
+  },
+}
+
+describe('renderLabelTextLayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('縦書きでは氏名と敬称を同一列で描画する', () => {
+    const ctx = createMockContext()
+
+    renderLabelTextLayer(
+      ctx as unknown as CanvasRenderingContext2D,
+      baseContact,
+      baseTemplate,
+      { pxPerMm: 1, showBackground: false, showBorder: false },
+    )
+
+    expect(drawVerticalBlock).toHaveBeenCalledTimes(2)
+    expect(drawVerticalBlock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        lines: ['山田太郎様'],
+        convertNumbers: false,
+      }),
+    )
+  })
+
+  it('横書きでは従来どおり氏名と敬称を全角スペース区切りで描画する', () => {
+    const ctx = createMockContext()
+    const fillText = vi.mocked(ctx.fillText)
+
+    renderLabelTextLayer(
+      ctx as unknown as CanvasRenderingContext2D,
+      baseContact,
+      { ...baseTemplate, orientation: 'horizontal' },
+      { pxPerMm: 1, showBackground: false, showBorder: false },
+    )
+
+    expect(drawVerticalBlock).not.toHaveBeenCalled()
+    const renderedTexts = fillText.mock.calls.map(([text]) => text)
+    expect(renderedTexts).toContain('山田太郎　様')
+  })
+})

--- a/frontend/src/lib/labelRenderer.ts
+++ b/frontend/src/lib/labelRenderer.ts
@@ -111,8 +111,8 @@ function renderVerticalLabel(
   {
     const rc = tpl.recipient
     const nameFontPx = ptToPx(rc.nameFont, pxPerMm)
-    const name = `${contact.familyName}${contact.givenName}`
     const honorific = contact.honorific || '様'
+    const fullName = `${contact.familyName}${contact.givenName}${honorific}`
 
     ctx.fillStyle = '#111827'
     const nameWeight = rc.nameBold ? 'bold' : 'normal'
@@ -120,7 +120,7 @@ function renderVerticalLabel(
 
     drawVerticalBlock({
       ctx,
-      lines: [honorific, name],
+      lines: [fullName],
       rightX: mmToPx(rc.nameX, pxPerMm),
       topY: mmToPx(rc.nameY, pxPerMm),
       fontSize: nameFontPx,

--- a/internal/infrastructure/pdf/label_pdf.go
+++ b/internal/infrastructure/pdf/label_pdf.go
@@ -799,8 +799,8 @@ func drawLabel(
 		// 縦書き: プレビュー drawVerticalBlock と同じ右端基準・列幅
 		setFont(rec.NameFont, rec.NameFontFamily)
 		nameFontMm := rec.NameFont * ptToMm
-		// プレビューと同じ列順: [敬称(最右列), 氏名]
-		drawVerticalBlockPDF(pdf, []string{honorific, contact.FamilyName + contact.GivenName},
+		// 縦書きは「氏名+敬称」を同一列で描画
+		drawVerticalBlockPDF(pdf, []string{contact.FamilyName + contact.GivenName + honorific},
 			ox+rec.NameX, oy+rec.NameY, nameFontMm)
 
 		setFont(rec.AddressFont, rec.AddressFontFamily)


### PR DESCRIPTION
## 概要
- 縦書きプレビューで敬称を別列にせず、氏名+敬称を同一列で描画
- PDF 出力でも同じ描画ロジックに揃えてプレビューと一致
- 横書きの氏名+全角スペース+敬称の表示は維持
- フロントに回帰テストを追加

## テスト
- npm --prefix frontend run test:run -- src/lib/labelRenderer.test.ts src/lib/labelSnapshot.parity.test.ts
- go test ./internal/infrastructure/pdf

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 縦書きレイアウトで敬称と名前の表示を最適化しました。敬称と名前の配置を改善し、PDF生成を含む全てのレンダリングに反映されます。

* **テスト**
  * ラベルレンダリング機能のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->