### PR TITLE
敬称を自由入力できるようにする

### DIFF
--- a/frontend/src/components/address/ContactEditModal.tsx
+++ b/frontend/src/components/address/ContactEditModal.tsx
@@ -105,6 +105,7 @@ export default function ContactEditModal({ contact, onClose, onSaved }: Props) {
     const errs: typeof errors = {}
     if (!form.familyName.trim()) errs.familyName = '姓は必須です'
     if (!form.givenName.trim()) errs.givenName = '名は必須です'
+    if (!form.honorific.trim()) errs.honorific = '敬称は必須です'
     return errs
   }
 
@@ -200,12 +201,20 @@ export default function ContactEditModal({ contact, onClose, onSaved }: Props) {
           </div>
 
           {/* 敬称 */}
-          <Field label="敬称" required>
-            <select value={form.honorific} onChange={set('honorific')} className={inputCls()}>
+          <Field label="敬称" required error={errors.honorific}>
+            <input
+              type="text"
+              list="honorific-candidates"
+              value={form.honorific}
+              onChange={set('honorific')}
+              className={inputCls(!!errors.honorific)}
+              placeholder="様"
+            />
+            <datalist id="honorific-candidates">
               {HONORIFICS.map((h) => (
-                <option key={h} value={h}>{h}</option>
+                <option key={h} value={h} />
               ))}
-            </select>
+            </datalist>
           </Field>
 
           {/* 郵便番号 */}

--- a/frontend/src/lib/labelRenderer.test.ts
+++ b/frontend/src/lib/labelRenderer.test.ts
@@ -110,4 +110,22 @@ describe('renderLabelTextLayer', () => {
     const renderedTexts = fillText.mock.calls.map(([text]) => text)
     expect(renderedTexts).toContain('山田太郎　様')
   })
+
+  it('任意の敬称をそのまま描画する', () => {
+    const ctx = createMockContext()
+
+    renderLabelTextLayer(
+      ctx as unknown as CanvasRenderingContext2D,
+      { ...baseContact, honorific: '各位' },
+      baseTemplate,
+      { pxPerMm: 1, showBackground: false, showBorder: false },
+    )
+
+    expect(drawVerticalBlock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        lines: ['山田太郎各位'],
+      }),
+    )
+  })
 })

--- a/internal/infrastructure/csv/csv_test.go
+++ b/internal/infrastructure/csv/csv_test.go
@@ -50,6 +50,21 @@ func TestImport(t *testing.T) {
 		}
 	})
 
+	t.Run("任意の敬称をインポート時に保持する", func(t *testing.T) {
+		content := "近藤,一樹,,,各位,1500001,東京都,渋谷区,1-2-3,,,,\n"
+		f := writeTempCSV(t, content)
+		contacts, errs := Import(f)
+		if len(errs) != 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if len(contacts) != 1 {
+			t.Fatalf("expected 1 contact, got %d", len(contacts))
+		}
+		if contacts[0].Honorific != "各位" {
+			t.Errorf("Honorific: got %q, want 各位", contacts[0].Honorific)
+		}
+	})
+
 	t.Run("敬称が空の場合は「様」になる", func(t *testing.T) {
 		content := "田中,次郎,,,,,,,,,,,\n"
 		f := writeTempCSV(t, content)
@@ -94,7 +109,7 @@ func TestExport(t *testing.T) {
 				ID:         "1",
 				FamilyName: "山田",
 				GivenName:  "太郎",
-				Honorific:  "様",
+				Honorific:  "御侍史",
 				PostalCode: "1234567",
 				Prefecture: "東京都",
 				City:       "渋谷区",
@@ -117,6 +132,9 @@ func TestExport(t *testing.T) {
 		}
 		if imported[0].FamilyName != "山田" {
 			t.Errorf("FamilyName: got %q", imported[0].FamilyName)
+		}
+		if imported[0].Honorific != "御侍史" {
+			t.Errorf("Honorific: got %q, want 御侍史", imported[0].Honorific)
 		}
 	})
 


### PR DESCRIPTION
## 概要
- 連絡先編集モーダルの敬称入力を自由入力 + 候補サジェストに変更
- 既存候補（様/殿/御中/先生）は datalist 候補として維持
- 敬称を必須バリデーションに追加
- 任意敬称がプレビュー描画に反映されるテストを追加
- 任意敬称が CSV import/export で保持されるテストを追加

## テスト
- go test ./internal/infrastructure/csv
- npm --prefix frontend run test:run -- src/lib/labelRenderer.test.ts
- npm --prefix frontend run build

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 敬称入力フィールドをセレクトボックスから自由入力テキストフィールドに変更し、入力候補のドロップダウン提案機能を追加しました。

* **改善**
  * 敬称フィールドのバリデーション機能を強化し、エラー表示を改善しました。

* **テスト**
  * 敬称入力処理とCSVインポート・エクスポート機能のテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->