### PR TITLE
[#60] CSV取込ウィザード（列マッピング・重複解決）を実装

### DIFF
--- a/app.go
+++ b/app.go
@@ -154,6 +154,33 @@ func (a *App) ImportCSV(filePath string) (entity.ImportResult, error) {
 	return result, nil
 }
 
+// GetCSVImportPlan returns headers, sample rows and suggested mapping for CSV import wizard.
+func (a *App) GetCSVImportPlan(filePath string) (entity.CSVImportPlan, error) {
+	plan, err := a.csvUseCase.CreateImportPlan(filePath)
+	if err != nil {
+		return entity.CSVImportPlan{}, fmt.Errorf("GetCSVImportPlan: %w", err)
+	}
+	return plan, nil
+}
+
+// AnalyzeCSVImport evaluates parse errors and duplicate candidates for CSV import wizard.
+func (a *App) AnalyzeCSVImport(filePath string, mapping map[string]int) (entity.CSVImportAnalysis, error) {
+	analysis, err := a.csvUseCase.AnalyzeImport(filePath, mapping)
+	if err != nil {
+		return entity.CSVImportAnalysis{}, fmt.Errorf("AnalyzeCSVImport: %w", err)
+	}
+	return analysis, nil
+}
+
+// ImportCSVWithOptions imports CSV with explicit duplicate resolutions.
+func (a *App) ImportCSVWithOptions(filePath string, mapping map[string]int, resolutions []entity.CSVDuplicateResolution) (entity.CSVImportExecutionResult, error) {
+	result, err := a.csvUseCase.ImportWithOptions(filePath, mapping, resolutions)
+	if err != nil {
+		return entity.CSVImportExecutionResult{}, fmt.Errorf("ImportCSVWithOptions: %w", err)
+	}
+	return result, nil
+}
+
 // ExportCSV exports the given contacts (or all if ids is empty) to a CSV file.
 func (a *App) ExportCSV(ids []string, filePath string) error {
 	if err := a.csvUseCase.Export(ids, filePath); err != nil {

--- a/frontend/src/components/address/CSVImportWizard.tsx
+++ b/frontend/src/components/address/CSVImportWizard.tsx
@@ -1,0 +1,376 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  AnalyzeCSVImport,
+  GetCSVImportPlan,
+  ImportCSVWithOptions,
+} from '../../../wailsjs/go/main/App'
+import type {
+  CSVImportAnalysis,
+  CSVImportExecutionResult,
+  CSVImportPlan,
+  CSVDuplicateResolution,
+} from '../../types'
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog'
+
+interface Props {
+  filePath: string
+  onClose: () => void
+  onCompleted: () => Promise<void>
+}
+
+type Step = 'mapping' | 'duplicates' | 'result'
+type DuplicateAction = 'new' | 'overwrite' | 'skip'
+
+export default function CSVImportWizard({ filePath, onClose, onCompleted }: Props) {
+  const [step, setStep] = useState<Step>('mapping')
+  const [loading, setLoading] = useState(false)
+  const [plan, setPlan] = useState<CSVImportPlan | null>(null)
+  const [mapping, setMapping] = useState<Record<string, number>>({})
+  const [analysis, setAnalysis] = useState<CSVImportAnalysis | null>(null)
+  const [resolutions, setResolutions] = useState<Record<number, DuplicateAction>>({})
+  const [result, setResult] = useState<CSVImportExecutionResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setError(null)
+    setPlan(null)
+    setAnalysis(null)
+    setResult(null)
+
+    GetCSVImportPlan(filePath)
+      .then((res) => {
+        if (!active) return
+        const typed = res as CSVImportPlan
+        setPlan(typed)
+        setMapping(typed.suggestedMapping ?? {})
+      })
+      .catch((err) => {
+        if (!active) return
+        console.error(err)
+        setError(`CSVの解析に失敗しました: ${String(err)}`)
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [filePath])
+
+  const canAnalyze = useMemo(() => {
+    if (!plan) return false
+    return plan.fieldDefinitions.every((field) => !field.required || (mapping[field.key] ?? -1) >= 0)
+  }, [plan, mapping])
+
+  const handleAnalyze = async () => {
+    if (!plan || !canAnalyze) return
+    setLoading(true)
+    setError(null)
+    try {
+      const analyzed = await AnalyzeCSVImport(filePath, mapping)
+      const typed = analyzed as CSVImportAnalysis
+      setAnalysis(typed)
+      const defaults: Record<number, DuplicateAction> = {}
+      typed.duplicates.forEach((dup) => {
+        const action = dup.suggestedAction ?? 'overwrite'
+        defaults[dup.rowNumber] = action
+      })
+      setResolutions(defaults)
+      setStep('duplicates')
+    } catch (err) {
+      console.error(err)
+      setError(`重複解析に失敗しました: ${String(err)}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleResolutionChange = (rowNumber: number, action: DuplicateAction) => {
+    setResolutions((prev) => ({ ...prev, [rowNumber]: action }))
+  }
+
+  const buildResolutionPayload = (): CSVDuplicateResolution[] => {
+    return Object.entries(resolutions).map(([rowNumber, action]) => ({
+      rowNumber: Number(rowNumber),
+      action,
+    }))
+  }
+
+  const handleExecute = async () => {
+    if (!plan) return
+    setLoading(true)
+    setError(null)
+    try {
+      const executed = await ImportCSVWithOptions(filePath, mapping, buildResolutionPayload())
+      await onCompleted()
+      setResult(executed as CSVImportExecutionResult)
+      setStep('result')
+    } catch (err) {
+      console.error(err)
+      setError(`CSV取込に失敗しました: ${String(err)}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>CSV取込ウィザード</DialogTitle>
+          <DialogClose
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+          >
+            &times;
+          </DialogClose>
+        </DialogHeader>
+
+        <div className="p-5 space-y-4">
+          <div className="text-xs text-gray-500">対象ファイル: {filePath}</div>
+
+          {loading && (
+            <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700">
+              処理中です...
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {step === 'mapping' && plan && (
+            <>
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold text-gray-800">1. 列マッピング</h3>
+                <p className="text-xs text-gray-500">
+                  取込対象: {plan.rowCount} 行 / 重複判定ルール: {plan.duplicateRule}
+                </p>
+                <div className="rounded-md border border-gray-200">
+                  <table className="w-full text-sm">
+                    <thead className="bg-gray-50 text-gray-600">
+                      <tr>
+                        <th className="px-3 py-2 text-left">項目</th>
+                        <th className="px-3 py-2 text-left">CSV列</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {plan.fieldDefinitions.map((field) => (
+                        <tr key={field.key} className="border-t border-gray-100">
+                          <td className="px-3 py-2">
+                            {field.label}
+                            {field.required ? <span className="ml-1 text-red-500">*</span> : null}
+                          </td>
+                          <td className="px-3 py-2">
+                            <select
+                              className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-sm"
+                              value={String(mapping[field.key] ?? -1)}
+                              onChange={(e) => {
+                                const next = Number(e.target.value)
+                                setMapping((prev) => ({ ...prev, [field.key]: next }))
+                              }}
+                            >
+                              <option value="-1">未使用</option>
+                              {plan.headers.map((header, idx) => (
+                                <option key={`${field.key}-${idx}`} value={idx}>
+                                  {header || `列${idx + 1}`}
+                                </option>
+                              ))}
+                            </select>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold text-gray-800">サンプル行</h3>
+                <div className="overflow-auto rounded-md border border-gray-200">
+                  <table className="w-full min-w-[720px] text-xs">
+                    <thead className="bg-gray-50 text-gray-600">
+                      <tr>
+                        {plan.headers.map((h, idx) => (
+                          <th key={idx} className="px-2 py-2 text-left font-medium">{h || `列${idx + 1}`}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {plan.sampleRows.map((row, rowIdx) => (
+                        <tr key={rowIdx} className="border-t border-gray-100">
+                          {plan.headers.map((_, colIdx) => (
+                            <td key={colIdx} className="px-2 py-2 text-gray-700">{row[colIdx] ?? ''}</td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={onClose}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  キャンセル
+                </button>
+                <button
+                  onClick={handleAnalyze}
+                  disabled={loading || !canAnalyze}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  重複チェックへ
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 'duplicates' && analysis && (
+            <>
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold text-gray-800">2. 重複解決</h3>
+                <p className="text-xs text-gray-500">
+                  有効行: {analysis.validRowCount} / 重複候補: {analysis.duplicates.length}
+                </p>
+                <p className="text-xs text-gray-500">{analysis.duplicateRule}</p>
+
+                {analysis.errors.length > 0 && (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                    <div className="font-medium">入力エラー ({analysis.errors.length}件)</div>
+                    <ul className="mt-1 list-disc pl-5 space-y-0.5">
+                      {analysis.errors.slice(0, 8).map((msg, idx) => (
+                        <li key={idx}>{msg}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {analysis.duplicates.length > 0 ? (
+                  <div className="overflow-auto rounded-md border border-gray-200">
+                    <table className="w-full min-w-[900px] text-xs">
+                      <thead className="bg-gray-50 text-gray-600">
+                        <tr>
+                          <th className="px-2 py-2 text-left">行</th>
+                          <th className="px-2 py-2 text-left">取込データ</th>
+                          <th className="px-2 py-2 text-left">既存データ</th>
+                          <th className="px-2 py-2 text-left">対応</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {analysis.duplicates.map((dup) => (
+                          <tr key={dup.rowNumber} className="border-t border-gray-100">
+                            <td className="px-2 py-2">{dup.rowNumber}</td>
+                            <td className="px-2 py-2">
+                              <div className="font-medium">{dup.incoming.displayName}</div>
+                              <div>{formatAddress(dup.incoming)}</div>
+                            </td>
+                            <td className="px-2 py-2">
+                              <div className="font-medium">{dup.existing.displayName}</div>
+                              <div>{formatAddress(dup.existing)}</div>
+                            </td>
+                            <td className="px-2 py-2">
+                              <select
+                                className="rounded border border-gray-300 bg-white px-2 py-1"
+                                value={resolutions[dup.rowNumber] ?? 'overwrite'}
+                                onChange={(e) => handleResolutionChange(dup.rowNumber, e.target.value as DuplicateAction)}
+                              >
+                                <option value="overwrite">上書き</option>
+                                <option value="new">新規作成</option>
+                                <option value="skip">スキップ</option>
+                              </select>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+                    重複候補はありません。このまま取り込みできます。
+                  </div>
+                )}
+              </section>
+
+              <div className="flex justify-between gap-2">
+                <button
+                  onClick={() => setStep('mapping')}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  戻る
+                </button>
+                <button
+                  onClick={handleExecute}
+                  disabled={loading}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  取り込み実行
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 'result' && result && (
+            <>
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold text-gray-800">3. 取込結果</h3>
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <Summary label="対象行" value={result.totalRows} />
+                  <Summary label="新規作成" value={result.created} />
+                  <Summary label="上書き" value={result.updated} />
+                  <Summary label="スキップ" value={result.skipped} />
+                  <Summary label="重複処理" value={result.duplicateResolved} />
+                  <Summary label="エラー" value={result.errors.length} />
+                </div>
+                {result.errors.length > 0 && (
+                  <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                    <div className="font-medium">エラー詳細</div>
+                    <ul className="mt-1 list-disc pl-5 space-y-0.5">
+                      {result.errors.slice(0, 12).map((msg, idx) => (
+                        <li key={idx}>{msg}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </section>
+
+              <div className="flex justify-end">
+                <button
+                  onClick={onClose}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+                >
+                  閉じる
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function formatAddress(data: {
+  postalCode: string
+  prefecture: string
+  city: string
+  street: string
+}) {
+  const postal = data.postalCode ? `〒${data.postalCode}` : ''
+  return [postal, data.prefecture, data.city, data.street].filter(Boolean).join(' ')
+}
+
+function Summary({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2">
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className="text-base font-semibold text-gray-800">{value}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -4,7 +4,6 @@ import {
   GetGroups,
   DeleteContacts,
   SearchContacts,
-  ImportCSV,
   ExportCSV,
   OpenCSVFileDialog,
   SaveCSVFileDialog,
@@ -16,6 +15,7 @@ import { useContactStore } from '../../stores/contactStore'
 import type { Contact, ContactYearStatus, Group } from '../../types'
 import ContactEditModal from './ContactEditModal'
 import GroupManageDialog from './GroupManageDialog'
+import CSVImportWizard from './CSVImportWizard'
 
 type EditableField = 'familyName' | 'givenName' | 'honorific' | 'postalCode' | 'prefecture' | 'city' | 'street'
 type NavigationMode = 'none' | 'enter' | 'tab'
@@ -75,6 +75,7 @@ export default function ContactList() {
   const [editTarget, setEditTarget] = useState<Contact | null | undefined>(undefined)
   // undefined = モーダル非表示, null = 新規作成, Contact = 編集
   const [showGroupManage, setShowGroupManage] = useState(false)
+  const [importWizardFilePath, setImportWizardFilePath] = useState<string | null>(null)
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null)
   const [inlineSaveError, setInlineSaveError] = useState<string | null>(null)
   const [savingCellKey, setSavingCellKey] = useState<string | null>(null)
@@ -217,17 +218,9 @@ export default function ContactList() {
     try {
       const filePath = await OpenCSVFileDialog()
       if (!filePath) return
-      const result = await ImportCSV(filePath)
-      const msg = `インポート完了: ${result.imported} 件`
-      if (result.errors && result.errors.length > 0) {
-        alert(`${msg}\n\nエラー:\n${result.errors.join('\n')}`)
-      } else {
-        alert(msg)
-      }
+      setImportWizardFilePath(filePath)
     } catch (err) {
       alert(`インポートに失敗しました: ${err}`)
-    } finally {
-      await refreshContacts()
     }
   }
 
@@ -910,6 +903,14 @@ export default function ContactList() {
         <GroupManageDialog
           onClose={() => setShowGroupManage(false)}
           onChanged={refreshGroups}
+        />
+      )}
+
+      {importWizardFilePath && (
+        <CSVImportWizard
+          filePath={importWizardFilePath}
+          onClose={() => setImportWizardFilePath(null)}
+          onCompleted={refreshContacts}
         />
       )}
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -117,6 +117,59 @@ export interface ImportResult {
   errors: string[]
 }
 
+export interface CSVImportField {
+  key: string
+  label: string
+  required: boolean
+}
+
+export interface CSVImportPlan {
+  headers: string[]
+  sampleRows: string[][]
+  suggestedMapping: Record<string, number>
+  fieldDefinitions: CSVImportField[]
+  rowCount: number
+  duplicateRule: string
+}
+
+export interface CSVContactSnapshot {
+  id?: string
+  displayName: string
+  postalCode: string
+  prefecture: string
+  city: string
+  street: string
+  company: string
+}
+
+export interface CSVDuplicateCandidate {
+  rowNumber: number
+  incoming: CSVContactSnapshot
+  existing: CSVContactSnapshot
+  suggestedAction: 'new' | 'overwrite' | 'skip'
+}
+
+export interface CSVImportAnalysis {
+  duplicateRule: string
+  validRowCount: number
+  errors: string[]
+  duplicates: CSVDuplicateCandidate[]
+}
+
+export interface CSVDuplicateResolution {
+  rowNumber: number
+  action: 'new' | 'overwrite' | 'skip'
+}
+
+export interface CSVImportExecutionResult {
+  totalRows: number
+  created: number
+  updated: number
+  skipped: number
+  duplicateResolved: number
+  errors: string[]
+}
+
 export interface PrintHistory {
   id: string
   printedAt: string

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -4,6 +4,8 @@ import {entity} from '../models';
 
 export function AddContactToGroup(arg1:string,arg2:string):Promise<void>;
 
+export function AnalyzeCSVImport(arg1:string,arg2:{[key: string]: number}):Promise<any>;
+
 export function DeleteContacts(arg1:Array<string>):Promise<void>;
 
 export function DeleteGroup(arg1:string):Promise<void>;
@@ -21,6 +23,8 @@ export function GenerateLabelPDF(arg1:entity.PrintJob,arg2:string):Promise<strin
 export function GenerateQRPreview(arg1:entity.QRConfig):Promise<Array<number>>;
 
 export function GetAppVersion():Promise<string>;
+
+export function GetCSVImportPlan(arg1:string):Promise<any>;
 
 export function GetContact(arg1:string):Promise<entity.Contact>;
 
@@ -43,6 +47,8 @@ export function GetTempPDFPath():Promise<string>;
 export function GetWatermarkPresets():Promise<Array<entity.Watermark>>;
 
 export function ImportCSV(arg1:string):Promise<entity.ImportResult>;
+
+export function ImportCSVWithOptions(arg1:string,arg2:{[key: string]: number},arg3:Array<any>):Promise<any>;
 
 export function ImportDB():Promise<boolean>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -6,6 +6,10 @@ export function AddContactToGroup(arg1, arg2) {
   return window['go']['main']['App']['AddContactToGroup'](arg1, arg2);
 }
 
+export function AnalyzeCSVImport(arg1, arg2) {
+  return window['go']['main']['App']['AnalyzeCSVImport'](arg1, arg2);
+}
+
 export function DeleteContacts(arg1) {
   return window['go']['main']['App']['DeleteContacts'](arg1);
 }
@@ -40,6 +44,10 @@ export function GenerateQRPreview(arg1) {
 
 export function GetAppVersion() {
   return window['go']['main']['App']['GetAppVersion']();
+}
+
+export function GetCSVImportPlan(arg1) {
+  return window['go']['main']['App']['GetCSVImportPlan'](arg1);
 }
 
 export function GetContact(arg1) {
@@ -84,6 +92,10 @@ export function GetWatermarkPresets() {
 
 export function ImportCSV(arg1) {
   return window['go']['main']['App']['ImportCSV'](arg1);
+}
+
+export function ImportCSVWithOptions(arg1, arg2, arg3) {
+  return window['go']['main']['App']['ImportCSVWithOptions'](arg1, arg2, arg3);
 }
 
 export function ImportDB() {

--- a/internal/entity/csv_import_wizard.go
+++ b/internal/entity/csv_import_wizard.go
@@ -1,0 +1,61 @@
+package entity
+
+// CSVImportField describes one internal contact field that can be mapped from CSV columns.
+type CSVImportField struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Required bool   `json:"required"`
+}
+
+// CSVImportPlan is the first-step payload for the CSV import wizard.
+type CSVImportPlan struct {
+	Headers          []string         `json:"headers"`
+	SampleRows       [][]string       `json:"sampleRows"`
+	SuggestedMapping map[string]int   `json:"suggestedMapping"`
+	FieldDefinitions []CSVImportField `json:"fieldDefinitions"`
+	RowCount         int              `json:"rowCount"`
+	DuplicateRule    string           `json:"duplicateRule"`
+}
+
+// CSVContactSnapshot is a compact view used in duplicate resolution screens.
+type CSVContactSnapshot struct {
+	ID          string `json:"id,omitempty"`
+	DisplayName string `json:"displayName"`
+	PostalCode  string `json:"postalCode"`
+	Prefecture  string `json:"prefecture"`
+	City        string `json:"city"`
+	Street      string `json:"street"`
+	Company     string `json:"company"`
+}
+
+// CSVDuplicateCandidate represents one incoming row that matches an existing contact.
+type CSVDuplicateCandidate struct {
+	RowNumber       int                `json:"rowNumber"`
+	Incoming        CSVContactSnapshot `json:"incoming"`
+	Existing        CSVContactSnapshot `json:"existing"`
+	SuggestedAction string             `json:"suggestedAction"`
+}
+
+// CSVImportAnalysis is the second-step payload for duplicate review.
+type CSVImportAnalysis struct {
+	DuplicateRule string                  `json:"duplicateRule"`
+	ValidRowCount int                     `json:"validRowCount"`
+	Errors        []string                `json:"errors"`
+	Duplicates    []CSVDuplicateCandidate `json:"duplicates"`
+}
+
+// CSVDuplicateResolution stores user's action for one duplicate row.
+type CSVDuplicateResolution struct {
+	RowNumber int    `json:"rowNumber"`
+	Action    string `json:"action"`
+}
+
+// CSVImportExecutionResult is the final summary returned after import execution.
+type CSVImportExecutionResult struct {
+	TotalRows         int      `json:"totalRows"`
+	Created           int      `json:"created"`
+	Updated           int      `json:"updated"`
+	Skipped           int      `json:"skipped"`
+	DuplicateResolved int      `json:"duplicateResolved"`
+	Errors            []string `json:"errors"`
+}

--- a/internal/usecase/csv_usecase.go
+++ b/internal/usecase/csv_usecase.go
@@ -177,7 +177,7 @@ func (uc *CSVUseCase) ImportWithOptions(filePath string, mapping map[string]int,
 	}
 
 	result := entity.CSVImportExecutionResult{
-		TotalRows: len(rows),
+		TotalRows: len(rows) + len(parseErrors),
 		Errors:    append([]string{}, parseErrors...),
 	}
 
@@ -214,8 +214,7 @@ func (uc *CSVUseCase) ImportWithOptions(filePath string, mapping map[string]int,
 				result.Errors = append(result.Errors, fmt.Sprintf("行 %d: 上書き対象が見つかりません", row.rowNumber))
 				continue
 			}
-			updated := row.contact
-			updated.ID = existingContact.ID
+			updated := mergeContactForOverwrite(*existingContact, row.contact, mapping)
 			if err := uc.repo.Update(&updated); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("行 %d: 上書き保存に失敗しました: %v", row.rowNumber, err))
 				continue
@@ -476,7 +475,7 @@ func mappedValue(row []string, mapping map[string]int, key string) string {
 func buildDuplicateKey(c entity.Contact) (string, bool) {
 	family := normalizeDuplicateToken(c.FamilyName)
 	given := normalizeDuplicateToken(c.GivenName)
-	postal := normalizeDuplicateToken(c.PostalCode)
+	postal := normalizePostalCodeForDuplicate(c.PostalCode)
 	pref := normalizeDuplicateToken(c.Prefecture)
 	city := normalizeDuplicateToken(c.City)
 	street := normalizeDuplicateToken(c.Street)
@@ -489,6 +488,60 @@ func buildDuplicateKey(c entity.Contact) (string, bool) {
 	}
 
 	return strings.Join([]string{family, given, postal, pref, city, street}, "|"), true
+}
+
+func mergeContactForOverwrite(existing entity.Contact, incoming entity.Contact, mapping map[string]int) entity.Contact {
+	updated := existing
+
+	if isMappedField(mapping, "familyName") {
+		updated.FamilyName = incoming.FamilyName
+	}
+	if isMappedField(mapping, "givenName") {
+		updated.GivenName = incoming.GivenName
+	}
+	if isMappedField(mapping, "familyNameKana") {
+		updated.FamilyNameKana = incoming.FamilyNameKana
+	}
+	if isMappedField(mapping, "givenNameKana") {
+		updated.GivenNameKana = incoming.GivenNameKana
+	}
+	if isMappedField(mapping, "honorific") {
+		updated.Honorific = incoming.Honorific
+	}
+	if isMappedField(mapping, "postalCode") {
+		updated.PostalCode = incoming.PostalCode
+	}
+	if isMappedField(mapping, "prefecture") {
+		updated.Prefecture = incoming.Prefecture
+	}
+	if isMappedField(mapping, "city") {
+		updated.City = incoming.City
+	}
+	if isMappedField(mapping, "street") {
+		updated.Street = incoming.Street
+	}
+	if isMappedField(mapping, "building") {
+		updated.Building = incoming.Building
+	}
+	if isMappedField(mapping, "company") {
+		updated.Company = incoming.Company
+	}
+	if isMappedField(mapping, "department") {
+		updated.Department = incoming.Department
+	}
+	if isMappedField(mapping, "notes") {
+		updated.Notes = incoming.Notes
+	}
+	if isMappedField(mapping, "isPrintTarget") {
+		updated.IsPrintTarget = incoming.IsPrintTarget
+	}
+
+	return updated
+}
+
+func isMappedField(mapping map[string]int, key string) bool {
+	idx, ok := mapping[key]
+	return ok && idx >= 0
 }
 
 func toSnapshot(c entity.Contact) entity.CSVContactSnapshot {
@@ -525,6 +578,24 @@ func normalizeDuplicateToken(value string) string {
 	s = strings.ReplaceAll(s, " ", "")
 	s = strings.ReplaceAll(s, "　", "")
 	return s
+}
+
+func normalizePostalCodeForDuplicate(value string) string {
+	normalized := normalizeDuplicateToken(value)
+	if normalized == "" {
+		return ""
+	}
+
+	var digits []rune
+	for _, r := range normalized {
+		if r >= '0' && r <= '9' {
+			digits = append(digits, r)
+		}
+	}
+	if len(digits) > 0 {
+		return string(digits)
+	}
+	return normalized
 }
 
 func normalizeHeader(header string) string {

--- a/internal/usecase/csv_usecase.go
+++ b/internal/usecase/csv_usecase.go
@@ -1,7 +1,14 @@
 package usecase
 
 import (
+	"bufio"
+	"encoding/csv"
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
 
 	"atena-label/internal/entity"
 	"atena-label/internal/repository"
@@ -17,6 +24,42 @@ type CSVPort interface {
 type CSVUseCase struct {
 	repo repository.ContactRepository
 	csv  CSVPort
+}
+
+const csvDuplicateRule = "氏名（姓+名）と住所（郵便番号・都道府県・市区町村・番地）が一致した場合に重複と判定します"
+
+var csvImportPostalCodeRe = regexp.MustCompile(`^\d{7}$`)
+
+type csvFieldSpec struct {
+	key           string
+	label         string
+	required      bool
+	fallbackIndex int
+	aliases       []string
+}
+
+var csvFieldSpecs = []csvFieldSpec{
+	{key: "familyName", label: "姓", required: true, fallbackIndex: 0, aliases: []string{"姓", "familyname", "family_name", "last_name", "lastname"}},
+	{key: "givenName", label: "名", required: true, fallbackIndex: 1, aliases: []string{"名", "givenname", "given_name", "first_name", "firstname"}},
+	{key: "familyNameKana", label: "姓（カナ）", fallbackIndex: 2, aliases: []string{"姓（カナ）", "姓(カナ)", "familynamekana", "family_name_kana"}},
+	{key: "givenNameKana", label: "名（カナ）", fallbackIndex: 3, aliases: []string{"名（カナ）", "名(カナ)", "givennamekana", "given_name_kana"}},
+	{key: "honorific", label: "敬称", fallbackIndex: 4, aliases: []string{"敬称", "honorific"}},
+	{key: "postalCode", label: "郵便番号", fallbackIndex: 5, aliases: []string{"郵便番号", "postalcode", "postal_code", "zip"}},
+	{key: "prefecture", label: "都道府県", fallbackIndex: 6, aliases: []string{"都道府県", "prefecture"}},
+	{key: "city", label: "市区町村", fallbackIndex: 7, aliases: []string{"市区町村", "city"}},
+	{key: "street", label: "番地", fallbackIndex: 8, aliases: []string{"番地", "street", "address1", "address_1"}},
+	{key: "building", label: "建物名", fallbackIndex: 9, aliases: []string{"建物名", "building", "address2", "address_2"}},
+	{key: "company", label: "会社名", fallbackIndex: 10, aliases: []string{"会社名", "company"}},
+	{key: "department", label: "部署名", fallbackIndex: 11, aliases: []string{"部署名", "department"}},
+	{key: "notes", label: "メモ", fallbackIndex: 12, aliases: []string{"メモ", "notes", "note"}},
+	{key: "isPrintTarget", label: "印刷対象", fallbackIndex: 13, aliases: []string{"印刷対象", "printtarget", "print_target"}},
+}
+
+type parsedCSVRow struct {
+	rowNumber    int
+	contact      entity.Contact
+	duplicate    bool
+	duplicateKey string
 }
 
 func NewCSVUseCase(repo repository.ContactRepository, csv CSVPort) *CSVUseCase {
@@ -42,6 +85,147 @@ func (uc *CSVUseCase) Import(filePath string) (entity.ImportResult, error) {
 			continue
 		}
 		result.Imported++
+	}
+
+	return result, nil
+}
+
+// CreateImportPlan reads headers and sample rows for the CSV import wizard.
+func (uc *CSVUseCase) CreateImportPlan(filePath string) (entity.CSVImportPlan, error) {
+	headers, rows, hasHeader, _, err := readCSVTable(filePath)
+	if err != nil {
+		return entity.CSVImportPlan{}, err
+	}
+
+	plan := entity.CSVImportPlan{
+		Headers:          headers,
+		SampleRows:       sampleRows(rows, 5),
+		SuggestedMapping: suggestMapping(headers, hasHeader),
+		FieldDefinitions: fieldDefinitions(),
+		RowCount:         len(rows),
+		DuplicateRule:    csvDuplicateRule,
+	}
+	return plan, nil
+}
+
+// AnalyzeImport evaluates parse errors and duplicate candidates for the given mapping.
+func (uc *CSVUseCase) AnalyzeImport(filePath string, mapping map[string]int) (entity.CSVImportAnalysis, error) {
+	rows, parseErrors, err := uc.parseRows(filePath, mapping)
+	if err != nil {
+		return entity.CSVImportAnalysis{}, err
+	}
+
+	existing, err := uc.repo.FindAll("")
+	if err != nil {
+		return entity.CSVImportAnalysis{}, fmt.Errorf("連絡先の取得に失敗しました: %w", err)
+	}
+
+	existingByKey := make(map[string][]entity.Contact)
+	for _, c := range existing {
+		if key, ok := buildDuplicateKey(c); ok {
+			existingByKey[key] = append(existingByKey[key], c)
+		}
+	}
+
+	duplicates := make([]entity.CSVDuplicateCandidate, 0)
+	for _, row := range rows {
+		if !row.duplicate {
+			continue
+		}
+		cands := existingByKey[row.duplicateKey]
+		if len(cands) == 0 {
+			continue
+		}
+		existingContact := cands[0]
+		duplicates = append(duplicates, entity.CSVDuplicateCandidate{
+			RowNumber:       row.rowNumber,
+			Incoming:        toSnapshot(row.contact),
+			Existing:        toSnapshot(existingContact),
+			SuggestedAction: "overwrite",
+		})
+	}
+
+	return entity.CSVImportAnalysis{
+		DuplicateRule: csvDuplicateRule,
+		ValidRowCount: len(rows),
+		Errors:        parseErrors,
+		Duplicates:    duplicates,
+	}, nil
+}
+
+// ImportWithOptions runs CSV import with explicit duplicate resolutions.
+func (uc *CSVUseCase) ImportWithOptions(filePath string, mapping map[string]int, resolutions []entity.CSVDuplicateResolution) (entity.CSVImportExecutionResult, error) {
+	rows, parseErrors, err := uc.parseRows(filePath, mapping)
+	if err != nil {
+		return entity.CSVImportExecutionResult{}, err
+	}
+
+	existing, err := uc.repo.FindAll("")
+	if err != nil {
+		return entity.CSVImportExecutionResult{}, fmt.Errorf("連絡先の取得に失敗しました: %w", err)
+	}
+	existingByKey := make(map[string][]entity.Contact)
+	for _, c := range existing {
+		if key, ok := buildDuplicateKey(c); ok {
+			existingByKey[key] = append(existingByKey[key], c)
+		}
+	}
+
+	resolutionByRow := make(map[int]string, len(resolutions))
+	for _, r := range resolutions {
+		resolutionByRow[r.RowNumber] = normalizeDuplicateAction(r.Action)
+	}
+
+	result := entity.CSVImportExecutionResult{
+		TotalRows: len(rows),
+		Errors:    append([]string{}, parseErrors...),
+	}
+
+	for _, row := range rows {
+		action := "new"
+		isDuplicate := false
+		var existingContact *entity.Contact
+
+		if row.duplicate {
+			matches := existingByKey[row.duplicateKey]
+			if len(matches) > 0 {
+				isDuplicate = true
+				existingContact = &matches[0]
+				action = resolutionByRow[row.rowNumber]
+				if action == "" {
+					action = "skip"
+				}
+			}
+		}
+
+		if isDuplicate {
+			result.DuplicateResolved++
+		}
+
+		switch action {
+		case "new":
+			if err := uc.repo.Create(&row.contact); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("行 %d: 保存に失敗しました: %v", row.rowNumber, err))
+				continue
+			}
+			result.Created++
+		case "overwrite":
+			if existingContact == nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("行 %d: 上書き対象が見つかりません", row.rowNumber))
+				continue
+			}
+			updated := row.contact
+			updated.ID = existingContact.ID
+			if err := uc.repo.Update(&updated); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("行 %d: 上書き保存に失敗しました: %v", row.rowNumber, err))
+				continue
+			}
+			result.Updated++
+		case "skip":
+			result.Skipped++
+		default:
+			result.Errors = append(result.Errors, fmt.Sprintf("行 %d: 不明な重複アクションです (%s)", row.rowNumber, action))
+		}
 	}
 
 	return result, nil
@@ -73,4 +257,329 @@ func (uc *CSVUseCase) Export(ids []string, filePath string) error {
 		return fmt.Errorf("CSVエクスポートに失敗しました: %w", err)
 	}
 	return nil
+}
+
+func (uc *CSVUseCase) parseRows(filePath string, mapping map[string]int) ([]parsedCSVRow, []string, error) {
+	_, rows, _, startLine, err := readCSVTable(filePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateMapping(mapping); err != nil {
+		return nil, nil, err
+	}
+
+	parsed := make([]parsedCSVRow, 0, len(rows))
+	errs := make([]string, 0)
+
+	for i, row := range rows {
+		lineNum := i + startLine
+		if isEmptyRow(row) {
+			continue
+		}
+		contact, err := mapRowToContact(row, lineNum, mapping)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		key, ok := buildDuplicateKey(contact)
+		parsed = append(parsed, parsedCSVRow{
+			rowNumber:    lineNum,
+			contact:      contact,
+			duplicate:    ok,
+			duplicateKey: key,
+		})
+	}
+
+	return parsed, errs, nil
+}
+
+func readCSVTable(filePath string) ([]string, [][]string, bool, int, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, nil, false, 0, fmt.Errorf("ファイルを開けません: %w", err)
+	}
+	defer f.Close()
+
+	br := bufio.NewReader(f)
+	if bom, _ := br.Peek(3); len(bom) == 3 && bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF {
+		_, _ = br.Discard(3)
+	}
+
+	r := csv.NewReader(br)
+	r.FieldsPerRecord = -1
+	r.LazyQuotes = true
+
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, nil, false, 0, fmt.Errorf("CSVの読み込みに失敗しました: %w", err)
+	}
+	if len(records) == 0 {
+		return []string{}, [][]string{}, false, 1, nil
+	}
+
+	hasHeader := isLikelyHeaderRow(records[0])
+	start := 0
+	startLine := 1
+	headers := []string{}
+	if hasHeader {
+		start = 1
+		startLine = 2
+		headers = trimRow(records[0])
+	} else {
+		maxCols := maxColumnCount(records)
+		headers = make([]string, maxCols)
+		for i := range headers {
+			headers[i] = fmt.Sprintf("列%d", i+1)
+		}
+	}
+
+	rows := make([][]string, 0, len(records)-start)
+	for i := start; i < len(records); i++ {
+		rows = append(rows, trimRow(records[i]))
+	}
+
+	return headers, rows, hasHeader, startLine, nil
+}
+
+func sampleRows(rows [][]string, max int) [][]string {
+	if len(rows) <= max {
+		return rows
+	}
+	return rows[:max]
+}
+
+func suggestMapping(headers []string, hasHeader bool) map[string]int {
+	mapping := make(map[string]int, len(csvFieldSpecs))
+	for _, spec := range csvFieldSpecs {
+		mapping[spec.key] = -1
+	}
+
+	if !hasHeader {
+		for _, spec := range csvFieldSpecs {
+			if spec.fallbackIndex < len(headers) {
+				mapping[spec.key] = spec.fallbackIndex
+			}
+		}
+		return mapping
+	}
+
+	headerIndex := make(map[string]int, len(headers))
+	for idx, h := range headers {
+		n := normalizeHeader(h)
+		if n == "" {
+			continue
+		}
+		if _, exists := headerIndex[n]; !exists {
+			headerIndex[n] = idx
+		}
+	}
+
+	for _, spec := range csvFieldSpecs {
+		for _, alias := range spec.aliases {
+			if idx, ok := headerIndex[normalizeHeader(alias)]; ok {
+				mapping[spec.key] = idx
+				break
+			}
+		}
+	}
+
+	return mapping
+}
+
+func fieldDefinitions() []entity.CSVImportField {
+	defs := make([]entity.CSVImportField, 0, len(csvFieldSpecs))
+	for _, spec := range csvFieldSpecs {
+		defs = append(defs, entity.CSVImportField{
+			Key:      spec.key,
+			Label:    spec.label,
+			Required: spec.required,
+		})
+	}
+	return defs
+}
+
+func validateMapping(mapping map[string]int) error {
+	if mapping == nil {
+		return fmt.Errorf("列マッピングが指定されていません")
+	}
+	for _, spec := range csvFieldSpecs {
+		if _, ok := mapping[spec.key]; !ok {
+			mapping[spec.key] = -1
+		}
+	}
+	for _, spec := range csvFieldSpecs {
+		if spec.required && mapping[spec.key] < 0 {
+			return fmt.Errorf("必須項目 %s のマッピングが未設定です", spec.label)
+		}
+	}
+	return nil
+}
+
+func mapRowToContact(row []string, lineNum int, mapping map[string]int) (entity.Contact, error) {
+	postal := mappedValue(row, mapping, "postalCode")
+	if postal != "" && !csvImportPostalCodeRe.MatchString(postal) {
+		return entity.Contact{}, fmt.Errorf("行 %d: 郵便番号が無効です (%q)", lineNum, postal)
+	}
+
+	printTargetRaw := mappedValue(row, mapping, "isPrintTarget")
+	printTarget, err := parsePrintTargetForWizard(printTargetRaw)
+	if err != nil {
+		return entity.Contact{}, fmt.Errorf("行 %d: 印刷対象の値が無効です (%q)", lineNum, printTargetRaw)
+	}
+
+	honorific := mappedValue(row, mapping, "honorific")
+	if honorific == "" {
+		honorific = "様"
+	}
+
+	contact := entity.Contact{
+		ID:             uuid.New().String(),
+		FamilyName:     mappedValue(row, mapping, "familyName"),
+		GivenName:      mappedValue(row, mapping, "givenName"),
+		FamilyNameKana: mappedValue(row, mapping, "familyNameKana"),
+		GivenNameKana:  mappedValue(row, mapping, "givenNameKana"),
+		Honorific:      honorific,
+		PostalCode:     postal,
+		Prefecture:     mappedValue(row, mapping, "prefecture"),
+		City:           mappedValue(row, mapping, "city"),
+		Street:         mappedValue(row, mapping, "street"),
+		Building:       mappedValue(row, mapping, "building"),
+		Company:        mappedValue(row, mapping, "company"),
+		Department:     mappedValue(row, mapping, "department"),
+		Notes:          mappedValue(row, mapping, "notes"),
+		IsPrintTarget:  printTarget,
+	}
+
+	return contact, nil
+}
+
+func parsePrintTargetForWizard(raw string) (bool, error) {
+	v := strings.TrimSpace(strings.ToLower(raw))
+	switch v {
+	case "", "1", "true", "on":
+		return true, nil
+	case "0", "false", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid print target: %q", raw)
+	}
+}
+
+func mappedValue(row []string, mapping map[string]int, key string) string {
+	idx, ok := mapping[key]
+	if !ok || idx < 0 || idx >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[idx])
+}
+
+func buildDuplicateKey(c entity.Contact) (string, bool) {
+	family := normalizeDuplicateToken(c.FamilyName)
+	given := normalizeDuplicateToken(c.GivenName)
+	postal := normalizeDuplicateToken(c.PostalCode)
+	pref := normalizeDuplicateToken(c.Prefecture)
+	city := normalizeDuplicateToken(c.City)
+	street := normalizeDuplicateToken(c.Street)
+
+	if family == "" || given == "" {
+		return "", false
+	}
+	if postal == "" && pref == "" && city == "" && street == "" {
+		return "", false
+	}
+
+	return strings.Join([]string{family, given, postal, pref, city, street}, "|"), true
+}
+
+func toSnapshot(c entity.Contact) entity.CSVContactSnapshot {
+	displayName := strings.TrimSpace(c.FamilyName + c.GivenName)
+	if displayName == "" {
+		displayName = strings.TrimSpace(c.Company)
+	}
+	if displayName == "" {
+		displayName = "(名称なし)"
+	}
+
+	return entity.CSVContactSnapshot{
+		ID:          c.ID,
+		DisplayName: displayName,
+		PostalCode:  c.PostalCode,
+		Prefecture:  c.Prefecture,
+		City:        c.City,
+		Street:      c.Street,
+		Company:     c.Company,
+	}
+}
+
+func normalizeDuplicateAction(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "new", "overwrite", "skip":
+		return strings.ToLower(strings.TrimSpace(action))
+	default:
+		return ""
+	}
+}
+
+func normalizeDuplicateToken(value string) string {
+	s := strings.TrimSpace(strings.ToLower(value))
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "　", "")
+	return s
+}
+
+func normalizeHeader(header string) string {
+	s := strings.TrimSpace(strings.ToLower(header))
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "　", "")
+	s = strings.ReplaceAll(s, "_", "")
+	s = strings.ReplaceAll(s, "-", "")
+	return s
+}
+
+func isLikelyHeaderRow(row []string) bool {
+	if len(row) == 0 {
+		return false
+	}
+
+	known := make(map[string]struct{})
+	for _, spec := range csvFieldSpecs {
+		for _, alias := range spec.aliases {
+			known[normalizeHeader(alias)] = struct{}{}
+		}
+	}
+
+	matches := 0
+	for _, col := range row {
+		if _, ok := known[normalizeHeader(col)]; ok {
+			matches++
+		}
+	}
+	return matches >= 2
+}
+
+func isEmptyRow(row []string) bool {
+	for _, v := range row {
+		if strings.TrimSpace(v) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func trimRow(row []string) []string {
+	trimmed := make([]string, len(row))
+	for i, v := range row {
+		trimmed[i] = strings.TrimSpace(v)
+	}
+	return trimmed
+}
+
+func maxColumnCount(rows [][]string) int {
+	max := 0
+	for _, row := range rows {
+		if len(row) > max {
+			max = len(row)
+		}
+	}
+	return max
 }

--- a/internal/usecase/csv_usecase_test.go
+++ b/internal/usecase/csv_usecase_test.go
@@ -1,0 +1,279 @@
+package usecase
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"atena-label/internal/entity"
+)
+
+type mockCSVUseCaseRepo struct {
+	findAllFn  func(groupID string) ([]entity.Contact, error)
+	findByIDFn func(id string) (*entity.Contact, error)
+	createFn   func(c *entity.Contact) error
+	updateFn   func(c *entity.Contact) error
+	deleteFn   func(id string) error
+	searchFn   func(query string) ([]entity.Contact, error)
+}
+
+func (m *mockCSVUseCaseRepo) FindAll(groupID string) ([]entity.Contact, error) {
+	if m.findAllFn != nil {
+		return m.findAllFn(groupID)
+	}
+	return []entity.Contact{}, nil
+}
+
+func (m *mockCSVUseCaseRepo) FindByID(id string) (*entity.Contact, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(id)
+	}
+	return nil, nil
+}
+
+func (m *mockCSVUseCaseRepo) Create(c *entity.Contact) error {
+	if m.createFn != nil {
+		return m.createFn(c)
+	}
+	return nil
+}
+
+func (m *mockCSVUseCaseRepo) Update(c *entity.Contact) error {
+	if m.updateFn != nil {
+		return m.updateFn(c)
+	}
+	return nil
+}
+
+func (m *mockCSVUseCaseRepo) Delete(id string) error {
+	if m.deleteFn != nil {
+		return m.deleteFn(id)
+	}
+	return nil
+}
+
+func (m *mockCSVUseCaseRepo) Search(query string) ([]entity.Contact, error) {
+	if m.searchFn != nil {
+		return m.searchFn(query)
+	}
+	return []entity.Contact{}, nil
+}
+
+type noopCSVPort struct{}
+
+func (p *noopCSVPort) Import(filePath string) ([]entity.Contact, []string)     { return nil, nil }
+func (p *noopCSVPort) Export(contacts []entity.Contact, filePath string) error { return nil }
+
+func TestCSVUseCase_ImportWithOptions_OverwritePreservesUnmappedFields(t *testing.T) {
+	csvPath := writeCSVFixture(t,
+		"姓,名,敬称,郵便番号\n"+
+			"山田,太郎,殿,1234567\n",
+	)
+
+	existing := entity.Contact{
+		ID:            "existing-1",
+		FamilyName:    "山田",
+		GivenName:     "太郎",
+		Honorific:     "様",
+		PostalCode:    "1234567",
+		Company:       "旧会社",
+		Department:    "旧部署",
+		Building:      "旧ビル",
+		Notes:         "旧メモ",
+		IsPrintTarget: true,
+	}
+
+	var updated entity.Contact
+	createCalls := 0
+	updateCalls := 0
+
+	uc := NewCSVUseCase(&mockCSVUseCaseRepo{
+		findAllFn: func(groupID string) ([]entity.Contact, error) {
+			return []entity.Contact{existing}, nil
+		},
+		createFn: func(c *entity.Contact) error {
+			createCalls++
+			return nil
+		},
+		updateFn: func(c *entity.Contact) error {
+			updateCalls++
+			updated = *c
+			return nil
+		},
+	}, &noopCSVPort{})
+
+	mapping := map[string]int{
+		"familyName":     0,
+		"givenName":      1,
+		"honorific":      2,
+		"postalCode":     3,
+		"familyNameKana": -1,
+		"givenNameKana":  -1,
+		"prefecture":     -1,
+		"city":           -1,
+		"street":         -1,
+		"building":       -1,
+		"company":        -1,
+		"department":     -1,
+		"notes":          -1,
+		"isPrintTarget":  -1,
+	}
+
+	result, err := uc.ImportWithOptions(csvPath, mapping, []entity.CSVDuplicateResolution{{
+		RowNumber: 2,
+		Action:    "overwrite",
+	}})
+	if err != nil {
+		t.Fatalf("ImportWithOptions error: %v", err)
+	}
+	if createCalls != 0 {
+		t.Fatalf("Create should not be called on overwrite, got %d", createCalls)
+	}
+	if updateCalls != 1 {
+		t.Fatalf("Update should be called once, got %d", updateCalls)
+	}
+	if updated.ID != existing.ID {
+		t.Fatalf("updated ID = %s, want %s", updated.ID, existing.ID)
+	}
+	if updated.Honorific != "殿" {
+		t.Fatalf("Honorific = %q, want 殿", updated.Honorific)
+	}
+	if updated.Company != existing.Company || updated.Department != existing.Department || updated.Building != existing.Building || updated.Notes != existing.Notes {
+		t.Fatalf("unmapped fields were changed unexpectedly: %+v", updated)
+	}
+	if result.Updated != 1 || result.Created != 0 || result.DuplicateResolved != 1 || result.TotalRows != 1 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+}
+
+func TestCSVUseCase_ImportWithOptions_DuplicateByPostalHyphenNormalization(t *testing.T) {
+	csvPath := writeCSVFixture(t,
+		"姓,名,郵便番号\n"+
+			"山田,太郎,1234567\n",
+	)
+
+	existing := entity.Contact{
+		ID:         "existing-2",
+		FamilyName: "山田",
+		GivenName:  "太郎",
+		PostalCode: "123-4567",
+	}
+
+	createCalls := 0
+	updateCalls := 0
+
+	uc := NewCSVUseCase(&mockCSVUseCaseRepo{
+		findAllFn: func(groupID string) ([]entity.Contact, error) {
+			return []entity.Contact{existing}, nil
+		},
+		createFn: func(c *entity.Contact) error {
+			createCalls++
+			return nil
+		},
+		updateFn: func(c *entity.Contact) error {
+			updateCalls++
+			return nil
+		},
+	}, &noopCSVPort{})
+
+	mapping := map[string]int{
+		"familyName":     0,
+		"givenName":      1,
+		"postalCode":     2,
+		"familyNameKana": -1,
+		"givenNameKana":  -1,
+		"honorific":      -1,
+		"prefecture":     -1,
+		"city":           -1,
+		"street":         -1,
+		"building":       -1,
+		"company":        -1,
+		"department":     -1,
+		"notes":          -1,
+		"isPrintTarget":  -1,
+	}
+
+	result, err := uc.ImportWithOptions(csvPath, mapping, []entity.CSVDuplicateResolution{{
+		RowNumber: 2,
+		Action:    "overwrite",
+	}})
+	if err != nil {
+		t.Fatalf("ImportWithOptions error: %v", err)
+	}
+	if createCalls != 0 {
+		t.Fatalf("Create should not be called when duplicate matches, got %d", createCalls)
+	}
+	if updateCalls != 1 {
+		t.Fatalf("Update should be called once, got %d", updateCalls)
+	}
+	if result.DuplicateResolved != 1 || result.Updated != 1 || result.Created != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestCSVUseCase_ImportWithOptions_TotalRowsIncludesParseErrors(t *testing.T) {
+	csvPath := writeCSVFixture(t,
+		"姓,名,郵便番号\n"+
+			"山田,太郎,1234567\n"+
+			"佐藤,花子,12-3456\n",
+	)
+
+	createCalls := 0
+
+	uc := NewCSVUseCase(&mockCSVUseCaseRepo{
+		findAllFn: func(groupID string) ([]entity.Contact, error) {
+			return []entity.Contact{}, nil
+		},
+		createFn: func(c *entity.Contact) error {
+			createCalls++
+			return nil
+		},
+	}, &noopCSVPort{})
+
+	mapping := map[string]int{
+		"familyName":     0,
+		"givenName":      1,
+		"postalCode":     2,
+		"familyNameKana": -1,
+		"givenNameKana":  -1,
+		"honorific":      -1,
+		"prefecture":     -1,
+		"city":           -1,
+		"street":         -1,
+		"building":       -1,
+		"company":        -1,
+		"department":     -1,
+		"notes":          -1,
+		"isPrintTarget":  -1,
+	}
+
+	result, err := uc.ImportWithOptions(csvPath, mapping, nil)
+	if err != nil {
+		t.Fatalf("ImportWithOptions error: %v", err)
+	}
+	if createCalls != 1 {
+		t.Fatalf("Create should be called once for valid row, got %d", createCalls)
+	}
+	if result.TotalRows != 2 {
+		t.Fatalf("TotalRows = %d, want 2", result.TotalRows)
+	}
+	if result.Created != 1 {
+		t.Fatalf("Created = %d, want 1", result.Created)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("Errors len = %d, want 1", len(result.Errors))
+	}
+}
+
+func writeCSVFixture(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fixture.csv")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## 概要
- CSV取込ウィザードを追加（列マッピング → 重複解決 → 結果サマリー）
- 重複判定ルール（氏名 + 住所）を実装
- 重複候補ごとに `new / overwrite / skip` を選択可能に実装
- 取込結果サマリー（件数/エラー/重複処理）を返却・表示

## 変更点
- `app.go`
  - `GetCSVImportPlan`, `AnalyzeCSVImport`, `ImportCSVWithOptions` を追加
- `internal/usecase/csv_usecase.go`
  - マッピング提案、重複解析、重複解決付き取込実行を追加
- `internal/entity/csv_import_wizard.go`
  - ウィザード用エンティティを追加
- `frontend/src/components/address/CSVImportWizard.tsx`
  - 3ステップのCSV取込UIを追加
- `frontend/src/components/address/ContactList.tsx`
  - 既存CSV取込ボタンをウィザード起動に変更
- `frontend/src/types.ts`
  - ウィザード用型定義を追加
- `frontend/wailsjs/go/main/App.d.ts`, `frontend/wailsjs/go/main/App.js`
  - 新規Wailsバインディングを追加

## テスト
- `go test ./...`
- `npm --prefix frontend run build`
- `npm --prefix frontend run test:run`

Closes #60