### PR TITLE
[#62] 外字・異体字の未対応文字警告を追加

### DIFF
--- a/app.go
+++ b/app.go
@@ -331,6 +331,18 @@ func (a *App) GenerateLabelPDF(job entity.PrintJob, outPath string) (string, err
 	return path, nil
 }
 
+// CheckUnsupportedCharacters returns unsupported glyph warnings grouped by contact.
+func (a *App) CheckUnsupportedCharacters(job entity.PrintJob) ([]entity.UnsupportedCharacterWarning, error) {
+	warnings, err := a.printUseCase.CheckUnsupportedCharacters(job)
+	if err != nil {
+		return nil, fmt.Errorf("CheckUnsupportedCharacters: %w", err)
+	}
+	if warnings == nil {
+		warnings = []entity.UnsupportedCharacterWarning{}
+	}
+	return warnings, nil
+}
+
 // PrintPDF opens the given PDF file in the OS default viewer/printer.
 func (a *App) PrintPDF(pdfPath string) error {
 	if err := a.printUseCase.Print(pdfPath); err != nil {

--- a/frontend/src/components/PrintConfirmDialog.tsx
+++ b/frontend/src/components/PrintConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import {
+  CheckUnsupportedCharacters,
   GenerateLabelPDF,
   GetTempPDFPath,
   PrintPDF,
@@ -75,6 +76,9 @@ async function renderWatermarkToDataURL(
 export default function PrintConfirmDialog({ onClose }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [unsupportedWarnings, setUnsupportedWarnings] = useState<entity.UnsupportedCharacterWarning[]>([])
+  const [unsupportedCheckLoading, setUnsupportedCheckLoading] = useState(false)
+  const [unsupportedCheckError, setUnsupportedCheckError] = useState<string | null>(null)
   const [selectedSenderId, setSelectedSenderId] = useState('')
   const [repeatFill, setRepeatFill] = useState(false)
   const [showBorder, setShowBorder] = useState(false)
@@ -179,12 +183,13 @@ export default function PrintConfirmDialog({ onClose }: Props) {
     : 0
   const count = printableContacts.length
   const printableContactIDs = Array.from(new Set(printableContacts.map((c) => c.id)))
-  const isPrintActionDisabled = loading || count === 0 || !annualFilterReady
+  const isPrintActionDisabled = loading || unsupportedCheckLoading || count === 0 || !annualFilterReady
   const labelsPerPage = layout.columns * layout.rows
 
   const paperLabel = `${layout.paperWidth}×${layout.paperHeight}mm (${layout.columns}列×${layout.rows}行)`
+  const printableContactKey = printableContacts.map((c) => c.id).join(',')
 
-  async function buildJob(includeLabelImages: boolean): Promise<entity.PrintJob> {
+  function resolveTemplateAndContactIDs() {
     const defaultTpl = orientation === 'horizontal' ? DEFAULT_TEMPLATE_HORIZONTAL : DEFAULT_TEMPLATE
     const tpl = selectedTemplate
       ? { ...selectedTemplate, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
@@ -199,6 +204,76 @@ export default function PrintConfirmDialog({ onClose }: Props) {
       }
       ids = filled.slice(0, labelsPerPage)
     }
+
+    return { tpl, ids }
+  }
+
+  useEffect(() => {
+    if (!annualFilterReady || count === 0) {
+      setUnsupportedWarnings([])
+      setUnsupportedCheckError(null)
+      setUnsupportedCheckLoading(false)
+      return
+    }
+
+    const defaultTpl = orientation === 'horizontal' ? DEFAULT_TEMPLATE_HORIZONTAL : DEFAULT_TEMPLATE
+    const tpl = selectedTemplate
+      ? { ...selectedTemplate, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
+      : { ...defaultTpl, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
+    let ids = printableContacts.map((c) => c.id)
+    if (repeatFill && ids.length > 0 && ids.length < labelsPerPage) {
+      const filled: string[] = []
+      while (filled.length < labelsPerPage) {
+        filled.push(...ids)
+      }
+      ids = filled.slice(0, labelsPerPage)
+    }
+    const checkJob = entity.PrintJob.createFrom({
+      contactIds: ids,
+      template: tpl,
+      senderId: selectedSenderId,
+      labelLayout: layout,
+      showBorder,
+    })
+
+    let active = true
+    setUnsupportedCheckLoading(true)
+    setUnsupportedCheckError(null)
+
+    CheckUnsupportedCharacters(checkJob)
+      .then((warnings) => {
+        if (!active) return
+        setUnsupportedWarnings(warnings ?? [])
+      })
+      .catch((e) => {
+        if (!active) return
+        setUnsupportedWarnings([])
+        setUnsupportedCheckError(formatError(e))
+      })
+      .finally(() => {
+        if (active) {
+          setUnsupportedCheckLoading(false)
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [
+    annualFilterReady,
+    count,
+    printableContactKey,
+    repeatFill,
+    labelsPerPage,
+    orientation,
+    selectedTemplate,
+    layout,
+    selectedSenderId,
+    showBorder,
+  ])
+
+  async function buildJob(includeLabelImages: boolean): Promise<entity.PrintJob> {
+    const { tpl, ids } = resolveTemplateAndContactIDs()
 
     // 透かしを PDF 用 base64 PNG に変換（プリセットは canvas レンダリング、カスタムは既存 data URL）
     // 互換フォールバック時は変換失敗を許容し、旧経路での継続を優先する。
@@ -386,6 +461,29 @@ export default function PrintConfirmDialog({ onClose }: Props) {
             <p className="text-xs text-amber-700 bg-amber-50 rounded px-2 py-1">
               年次ステータスを読み込み中です。読み込み完了後に抽出・印刷できます。
             </p>
+          )}
+          {unsupportedCheckLoading && count > 0 && annualFilterReady && (
+            <p className="text-xs text-gray-600 bg-gray-100 rounded px-2 py-1">
+              文字対応を確認中です...
+            </p>
+          )}
+          {unsupportedCheckError && (
+            <p className="text-xs text-amber-700 bg-amber-50 rounded px-2 py-1">
+              未対応文字チェックに失敗しました。印刷時に文字化けがないか確認してください。
+            </p>
+          )}
+          {unsupportedWarnings.length > 0 && (
+            <div className="text-xs text-amber-900 bg-amber-50 rounded px-2 py-2 space-y-1">
+              <p className="font-medium">未対応文字の可能性があります（印刷前確認）</p>
+              {unsupportedWarnings.slice(0, 5).map((warning) => (
+                <p key={`${warning.contactId}-${warning.characters.join('')}`}>
+                  {warning.contactName || warning.contactId}: {warning.characters.join(' ')}
+                </p>
+              ))}
+              {unsupportedWarnings.length > 5 && (
+                <p>ほか {unsupportedWarnings.length - 5} 件</p>
+              )}
+            </div>
           )}
           <div className="flex justify-between">
             <span className="text-gray-500">印刷件数</span>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -22,6 +22,8 @@ export function GenerateLabelPDF(arg1:entity.PrintJob,arg2:string):Promise<strin
 
 export function GenerateQRPreview(arg1:entity.QRConfig):Promise<Array<number>>;
 
+export function CheckUnsupportedCharacters(arg1:entity.PrintJob):Promise<Array<entity.UnsupportedCharacterWarning>>;
+
 export function GetAppVersion():Promise<string>;
 
 export function GetCSVImportPlan(arg1:string):Promise<any>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -42,6 +42,10 @@ export function GenerateQRPreview(arg1) {
   return window['go']['main']['App']['GenerateQRPreview'](arg1);
 }
 
+export function CheckUnsupportedCharacters(arg1) {
+  return window['go']['main']['App']['CheckUnsupportedCharacters'](arg1);
+}
+
 export function GetAppVersion() {
   return window['go']['main']['App']['GetAppVersion']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -421,6 +421,23 @@ export namespace entity {
 		    return a;
 		}
 	}
+
+	export class UnsupportedCharacterWarning {
+	    contactId: string;
+	    contactName: string;
+	    characters: string[];
+
+	    static createFrom(source: any = {}) {
+	        return new UnsupportedCharacterWarning(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.contactId = source["contactId"];
+	        this.contactName = source["contactName"];
+	        this.characters = source["characters"];
+	    }
+	}
 	
 	export class Sender {
 	    id: string;

--- a/internal/entity/unsupported_character_warning.go
+++ b/internal/entity/unsupported_character_warning.go
@@ -1,0 +1,8 @@
+package entity
+
+// UnsupportedCharacterWarning represents unsupported glyphs detected before printing.
+type UnsupportedCharacterWarning struct {
+	ContactID   string   `json:"contactId"`
+	ContactName string   `json:"contactName"`
+	Characters  []string `json:"characters"`
+}

--- a/internal/infrastructure/pdf/label_pdf.go
+++ b/internal/infrastructure/pdf/label_pdf.go
@@ -9,7 +9,9 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/jung-kurt/gofpdf"
 	qrcode "github.com/skip2/go-qrcode"
@@ -527,6 +529,437 @@ func drawLabelImages(
 	}
 
 	return nil
+}
+
+type textSegment struct {
+	Field      string
+	FontFamily string
+	Text       string
+}
+
+type fontRuneChecker struct {
+	fmt4  *cmapFormat4
+	fmt12 []cmapFormat12Group
+}
+
+type cmapFormat4 struct {
+	data      []byte
+	segCount  int
+	endBase   int
+	startBase int
+	deltaBase int
+	rangeBase int
+}
+
+type cmapFormat12Group struct {
+	startCode uint32
+	endCode   uint32
+	startGID  uint32
+}
+
+func newFontRuneChecker(fontBytes []byte) *fontRuneChecker {
+	if len(fontBytes) == 0 {
+		return &fontRuneChecker{}
+	}
+
+	cmap := findCmapTable(fontBytes)
+	if len(cmap) == 0 {
+		return &fontRuneChecker{}
+	}
+
+	fmt4, fmt12 := parseUnicodeCmaps(cmap)
+	return &fontRuneChecker{
+		fmt4:  fmt4,
+		fmt12: fmt12,
+	}
+}
+
+func (c *fontRuneChecker) SupportsRune(r rune) bool {
+	if r == '\n' || r == '\r' || r == '\t' {
+		return true
+	}
+	if r >= 0x20 && r <= 0x7E {
+		return true
+	}
+	if c == nil {
+		return false
+	}
+
+	if c.fmt4 != nil && r >= 0 && r <= 0xFFFF {
+		if supportsRuneFormat4(c.fmt4, uint16(r)) {
+			return true
+		}
+	}
+	if len(c.fmt12) > 0 && supportsRuneFormat12(c.fmt12, uint32(r)) {
+		return true
+	}
+	return false
+}
+
+func findCmapTable(ttfBytes []byte) []byte {
+	if len(ttfBytes) < 12 {
+		return nil
+	}
+	numTables := int(binary.BigEndian.Uint16(ttfBytes[4:6]))
+	for i := 0; i < numTables; i++ {
+		base := 12 + i*16
+		if base+16 > len(ttfBytes) {
+			return nil
+		}
+		if string(ttfBytes[base:base+4]) != "cmap" {
+			continue
+		}
+		off := binary.BigEndian.Uint32(ttfBytes[base+8 : base+12])
+		length := binary.BigEndian.Uint32(ttfBytes[base+12 : base+16])
+		if off == 0 || length == 0 || int(off+length) > len(ttfBytes) {
+			return nil
+		}
+		return ttfBytes[off : off+length]
+	}
+	return nil
+}
+
+func parseUnicodeCmaps(cmap []byte) (*cmapFormat4, []cmapFormat12Group) {
+	if len(cmap) < 4 {
+		return nil, nil
+	}
+	numSubtables := int(binary.BigEndian.Uint16(cmap[2:4]))
+	var fmt4Off, fmt12Off uint32
+	for i := 0; i < numSubtables; i++ {
+		base := 4 + i*8
+		if base+8 > len(cmap) {
+			break
+		}
+		platformID := binary.BigEndian.Uint16(cmap[base : base+2])
+		encodingID := binary.BigEndian.Uint16(cmap[base+2 : base+4])
+		off := binary.BigEndian.Uint32(cmap[base+4 : base+8])
+		if off+2 > uint32(len(cmap)) {
+			continue
+		}
+		format := binary.BigEndian.Uint16(cmap[off : off+2])
+		switch format {
+		case 4:
+			if platformID == 3 && encodingID == 1 {
+				fmt4Off = off
+			} else if platformID == 0 && encodingID >= 3 && fmt4Off == 0 {
+				fmt4Off = off
+			} else if fmt4Off == 0 {
+				fmt4Off = off
+			}
+		case 12:
+			if (platformID == 3 && encodingID == 10) || (platformID == 0 && encodingID == 4) {
+				if fmt12Off == 0 {
+					fmt12Off = off
+				}
+			} else if fmt12Off == 0 {
+				fmt12Off = off
+			}
+		}
+	}
+
+	var parsedFmt4 *cmapFormat4
+	if fmt4Off != 0 {
+		parsedFmt4 = parseCmapFormat4(cmap, fmt4Off)
+	}
+	var parsedFmt12 []cmapFormat12Group
+	if fmt12Off != 0 {
+		parsedFmt12 = parseCmapFormat12(cmap, fmt12Off)
+	}
+	return parsedFmt4, parsedFmt12
+}
+
+func parseCmapFormat4(cmap []byte, off uint32) *cmapFormat4 {
+	if int(off)+16 > len(cmap) {
+		return nil
+	}
+	sub := cmap[off:]
+	segCount := int(binary.BigEndian.Uint16(sub[6:8])) / 2
+	if segCount <= 0 {
+		return nil
+	}
+
+	endBase := 14
+	startBase := endBase + segCount*2 + 2
+	deltaBase := startBase + segCount*2
+	rangeBase := deltaBase + segCount*2
+	if rangeBase+segCount*2 > len(sub) {
+		return nil
+	}
+
+	return &cmapFormat4{
+		data:      sub,
+		segCount:  segCount,
+		endBase:   endBase,
+		startBase: startBase,
+		deltaBase: deltaBase,
+		rangeBase: rangeBase,
+	}
+}
+
+func parseCmapFormat12(cmap []byte, off uint32) []cmapFormat12Group {
+	if int(off)+16 > len(cmap) {
+		return nil
+	}
+	sub := cmap[off:]
+	numGroups := int(binary.BigEndian.Uint32(sub[12:16]))
+	if numGroups <= 0 || 16+numGroups*12 > len(sub) {
+		return nil
+	}
+
+	groups := make([]cmapFormat12Group, 0, numGroups)
+	for i := 0; i < numGroups; i++ {
+		base := 16 + i*12
+		groups = append(groups, cmapFormat12Group{
+			startCode: binary.BigEndian.Uint32(sub[base : base+4]),
+			endCode:   binary.BigEndian.Uint32(sub[base+4 : base+8]),
+			startGID:  binary.BigEndian.Uint32(sub[base+8 : base+12]),
+		})
+	}
+	return groups
+}
+
+func supportsRuneFormat4(fmt4 *cmapFormat4, cp uint16) bool {
+	sub := fmt4.data
+	for s := 0; s < fmt4.segCount; s++ {
+		end := binary.BigEndian.Uint16(sub[fmt4.endBase+s*2 : fmt4.endBase+s*2+2])
+		if cp > end {
+			continue
+		}
+
+		start := binary.BigEndian.Uint16(sub[fmt4.startBase+s*2 : fmt4.startBase+s*2+2])
+		if cp < start {
+			return false
+		}
+
+		delta := int16(binary.BigEndian.Uint16(sub[fmt4.deltaBase+s*2 : fmt4.deltaBase+s*2+2]))
+		rangeOff := binary.BigEndian.Uint16(sub[fmt4.rangeBase+s*2 : fmt4.rangeBase+s*2+2])
+		if rangeOff == 0 {
+			return uint16(int(cp)+int(delta)) != 0
+		}
+
+		// idRangeOffset points to a glyph ID array relative to the current idRangeOffset word.
+		rangeWordPos := fmt4.rangeBase + s*2
+		glyphPos := rangeWordPos + int(rangeOff) + int(cp-start)*2
+		if glyphPos+2 > len(sub) {
+			return false
+		}
+		glyph := binary.BigEndian.Uint16(sub[glyphPos : glyphPos+2])
+		if glyph == 0 {
+			return false
+		}
+		glyph = uint16(int(glyph) + int(delta))
+		return glyph != 0
+	}
+	return false
+}
+
+func supportsRuneFormat12(groups []cmapFormat12Group, cp uint32) bool {
+	low, high := 0, len(groups)-1
+	for low <= high {
+		mid := low + (high-low)/2
+		g := groups[mid]
+		if cp < g.startCode {
+			high = mid - 1
+			continue
+		}
+		if cp > g.endCode {
+			low = mid + 1
+			continue
+		}
+		gid := g.startGID + (cp - g.startCode)
+		return gid != 0
+	}
+	return false
+}
+
+func formatPostalCodeForLabel(raw string) string {
+	digits := strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' {
+			return r
+		}
+		return -1
+	}, raw)
+	if len(digits) == 7 {
+		return digits[:3] + "-" + digits[3:]
+	}
+	return digits
+}
+
+func collectAddressLines(contact entity.Contact) []string {
+	addrLine1 := contact.Prefecture + contact.City
+	addrLine2 := contact.Street
+	if contact.Building != "" {
+		addrLine2 += "\u3000" + contact.Building
+	}
+	lines := []string{}
+	if addrLine1 != "" {
+		lines = append(lines, addrLine1)
+	}
+	if addrLine2 != "" {
+		lines = append(lines, addrLine2)
+	}
+	return lines
+}
+
+func labelTextSegments(contact entity.Contact, tmpl entity.Template) []textSegment {
+	segments := []textSegment{}
+
+	if tmpl.PostalCode != nil && contact.PostalCode != "" {
+		segments = append(segments, textSegment{
+			Field:      "postalCode",
+			FontFamily: tmpl.PostalCode.FontFamily,
+			Text:       "〒" + formatPostalCodeForLabel(contact.PostalCode),
+		})
+	}
+
+	rec := tmpl.Recipient
+	honorific := contact.Honorific
+	if honorific == "" {
+		honorific = "様"
+	}
+
+	if tmpl.Orientation == "vertical" {
+		segments = append(segments, textSegment{
+			Field:      "recipientName",
+			FontFamily: rec.NameFontFamily,
+			Text:       contact.FamilyName + contact.GivenName + honorific,
+		})
+		for _, line := range collectAddressLines(contact) {
+			segments = append(segments, textSegment{
+				Field:      "recipientAddress",
+				FontFamily: rec.AddressFontFamily,
+				Text:       toKanjiNumerals(line),
+			})
+		}
+		return segments
+	}
+
+	if contact.Company != "" {
+		segments = append(segments, textSegment{
+			Field:      "recipientName",
+			FontFamily: rec.NameFontFamily,
+			Text:       contact.Company,
+		})
+		if contact.Department != "" {
+			segments = append(segments, textSegment{
+				Field:      "recipientName",
+				FontFamily: rec.NameFontFamily,
+				Text:       contact.Department,
+			})
+		}
+	}
+	segments = append(segments, textSegment{
+		Field:      "recipientName",
+		FontFamily: rec.NameFontFamily,
+		Text:       contact.FamilyName + contact.GivenName + "\u3000" + honorific,
+	})
+	for _, line := range collectAddressLines(contact) {
+		segments = append(segments, textSegment{
+			Field:      "recipientAddress",
+			FontFamily: rec.AddressFontFamily,
+			Text:       line,
+		})
+	}
+	return segments
+}
+
+func fallbackContactName(contact entity.Contact) string {
+	name := strings.TrimSpace(contact.FamilyName + contact.GivenName)
+	if name != "" {
+		return name
+	}
+	if contact.Company != "" {
+		return contact.Company
+	}
+	return contact.ID
+}
+
+func shouldSkipGlyphCheckRune(r rune) bool {
+	return unicode.IsSpace(r) || unicode.IsControl(r)
+}
+
+// DetectUnsupportedCharacters checks whether each printable rune can be rendered by the selected font family.
+func (g *Generator) DetectUnsupportedCharacters(
+	job entity.PrintJob,
+	contacts []entity.Contact,
+) ([]entity.UnsupportedCharacterWarning, error) {
+	serifChecker := newFontRuneChecker(g.fontBytes)
+	sansChecker := newFontRuneChecker(g.sansFontBytes)
+	hasSerifFont := len(g.fontBytes) > 0
+	hasSansFont := len(g.sansFontBytes) > 0
+
+	selectChecker := func(family string) *fontRuneChecker {
+		if family == "sans-serif" && hasSansFont {
+			return sansChecker
+		}
+		if hasSerifFont {
+			return serifChecker
+		}
+		return &fontRuneChecker{}
+	}
+
+	warnings := make([]entity.UnsupportedCharacterWarning, 0)
+	warningIndexByContact := make(map[string]int, len(contacts))
+
+	for _, contact := range contacts {
+		segments := labelTextSegments(contact, job.Template)
+		if len(segments) == 0 {
+			continue
+		}
+
+		unsupportedRunes := make(map[rune]struct{})
+		for _, segment := range segments {
+			checker := selectChecker(segment.FontFamily)
+			for _, r := range segment.Text {
+				if shouldSkipGlyphCheckRune(r) {
+					continue
+				}
+				if !checker.SupportsRune(r) {
+					unsupportedRunes[r] = struct{}{}
+				}
+			}
+		}
+		if len(unsupportedRunes) == 0 {
+			continue
+		}
+
+		runes := make([]rune, 0, len(unsupportedRunes))
+		for r := range unsupportedRunes {
+			runes = append(runes, r)
+		}
+		sort.Slice(runes, func(i, j int) bool { return runes[i] < runes[j] })
+
+		chars := make([]string, 0, len(runes))
+		for _, r := range runes {
+			chars = append(chars, string(r))
+		}
+
+		idx, exists := warningIndexByContact[contact.ID]
+		if !exists {
+			warnings = append(warnings, entity.UnsupportedCharacterWarning{
+				ContactID:   contact.ID,
+				ContactName: fallbackContactName(contact),
+				Characters:  chars,
+			})
+			warningIndexByContact[contact.ID] = len(warnings) - 1
+			continue
+		}
+
+		// Merge duplicates when the same contact appears multiple times (e.g. repeat fill).
+		existing := make(map[string]struct{}, len(warnings[idx].Characters))
+		for _, ch := range warnings[idx].Characters {
+			existing[ch] = struct{}{}
+		}
+		for _, ch := range chars {
+			if _, ok := existing[ch]; ok {
+				continue
+			}
+			warnings[idx].Characters = append(warnings[idx].Characters, ch)
+		}
+		sort.Strings(warnings[idx].Characters)
+	}
+
+	return warnings, nil
 }
 
 // GenerateLabelPDF generates an A4 label PDF and returns the raw bytes.

--- a/internal/infrastructure/pdf/label_pdf_test.go
+++ b/internal/infrastructure/pdf/label_pdf_test.go
@@ -2,7 +2,10 @@ package pdf
 
 import (
 	"os"
+	"strings"
 	"testing"
+
+	"atena-label/internal/entity"
 )
 
 // TestJapaneseCmapScoreWithSongti verifies that the Traditional Chinese face
@@ -61,6 +64,83 @@ func TestExtractTTFFromTTCRoundtrip(t *testing.T) {
 		t.Fatal("empty font bytes from validateFontBytes")
 	}
 	t.Logf("Font bytes: %d", len(fb))
+}
+
+func TestDetectUnsupportedCharacters_NoFontsWarnsNonASCII(t *testing.T) {
+	g := &Generator{}
+	job := entity.PrintJob{
+		Template: entity.Template{
+			Orientation: "vertical",
+			Recipient: entity.TextConfig{
+				NameFontFamily:    "serif",
+				AddressFontFamily: "serif",
+			},
+		},
+	}
+	contacts := []entity.Contact{
+		{
+			ID:         "c1",
+			FamilyName: "髙橋",
+			GivenName:  "太郎",
+			Prefecture: "東京都",
+			City:       "渋谷区",
+		},
+	}
+
+	warnings, err := g.DetectUnsupportedCharacters(job, contacts)
+	if err != nil {
+		t.Fatalf("DetectUnsupportedCharacters: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warning count = %d, want 1", len(warnings))
+	}
+	if warnings[0].ContactID != "c1" {
+		t.Fatalf("warning contact ID = %q, want c1", warnings[0].ContactID)
+	}
+	if !containsString(warnings[0].Characters, "髙") {
+		t.Fatalf("expected unsupported chars to include 髙, got %v", warnings[0].Characters)
+	}
+}
+
+func TestDetectUnsupportedCharacters_NoFontsASCIIOnly(t *testing.T) {
+	g := &Generator{}
+	job := entity.PrintJob{
+		Template: entity.Template{
+			Orientation: "horizontal",
+			Recipient: entity.TextConfig{
+				NameFontFamily:    "serif",
+				AddressFontFamily: "serif",
+			},
+		},
+	}
+	contacts := []entity.Contact{
+		{
+			ID:         "c1",
+			FamilyName: "John",
+			GivenName:  "Smith",
+			Honorific:  "Mr",
+			Prefecture: "CA",
+			City:       "SF",
+			Street:     "1st-Street",
+		},
+	}
+
+	warnings, err := g.DetectUnsupportedCharacters(job, contacts)
+	if err != nil {
+		t.Fatalf("DetectUnsupportedCharacters: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warning count = %d, want 0 (%v)", len(warnings), warnings)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, target) {
+			return true
+		}
+	}
+	return false
 }
 
 func readUint32BE(b []byte) uint32 {

--- a/internal/repository/pdf_repository.go
+++ b/internal/repository/pdf_repository.go
@@ -5,4 +5,5 @@ import "atena-label/internal/entity"
 // PDFGenerator generates a label PDF from a print job.
 type PDFGenerator interface {
 	GenerateLabelPDF(job entity.PrintJob, contacts []entity.Contact, sender *entity.Sender) ([]byte, error)
+	DetectUnsupportedCharacters(job entity.PrintJob, contacts []entity.Contact) ([]entity.UnsupportedCharacterWarning, error)
 }

--- a/internal/usecase/print_usecase.go
+++ b/internal/usecase/print_usecase.go
@@ -52,21 +52,13 @@ func (uc *PrintUseCase) GenerateLabelPDF(job entity.PrintJob, outPath string) (s
 		)
 	}
 
-	contacts := make([]entity.Contact, 0, len(job.ContactIDs))
+	contacts := []entity.Contact{}
 	if !useLabelImages {
 		// Resolve contacts for the legacy backend-rendering flow.
-		for _, id := range job.ContactIDs {
-			c, err := uc.contactRepo.FindByID(id)
-			if err != nil {
-				return "", fmt.Errorf("contact %s: %w", id, err)
-			}
-			if c == nil {
-				return "", fmt.Errorf("contact %s: not found", id)
-			}
-			contacts = append(contacts, *c)
-		}
-		if len(contacts) == 0 {
-			return "", fmt.Errorf("no contacts specified for printing")
+		var err error
+		contacts, err = uc.resolveContacts(job.ContactIDs, false)
+		if err != nil {
+			return "", err
 		}
 	}
 
@@ -94,4 +86,54 @@ func (uc *PrintUseCase) GenerateLabelPDF(job entity.PrintJob, outPath string) (s
 		return "", fmt.Errorf("write PDF file: %w", err)
 	}
 	return outPath, nil
+}
+
+// CheckUnsupportedCharacters scans printable text and returns unsupported glyph warnings per contact.
+func (uc *PrintUseCase) CheckUnsupportedCharacters(job entity.PrintJob) ([]entity.UnsupportedCharacterWarning, error) {
+	contacts, err := uc.resolveContacts(job.ContactIDs, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(contacts) == 0 {
+		return []entity.UnsupportedCharacterWarning{}, nil
+	}
+
+	warnings, err := uc.pdfGenerator.DetectUnsupportedCharacters(job, contacts)
+	if err != nil {
+		return nil, fmt.Errorf("detect unsupported characters: %w", err)
+	}
+	if warnings == nil {
+		return []entity.UnsupportedCharacterWarning{}, nil
+	}
+	return warnings, nil
+}
+
+func (uc *PrintUseCase) resolveContacts(contactIDs []string, allowEmpty bool) ([]entity.Contact, error) {
+	if len(contactIDs) == 0 {
+		if allowEmpty {
+			return []entity.Contact{}, nil
+		}
+		return nil, fmt.Errorf("no contacts specified for printing")
+	}
+
+	contacts := make([]entity.Contact, 0, len(contactIDs))
+	cache := make(map[string]*entity.Contact, len(contactIDs))
+	for _, id := range contactIDs {
+		if cached, ok := cache[id]; ok {
+			contacts = append(contacts, *cached)
+			continue
+		}
+
+		c, err := uc.contactRepo.FindByID(id)
+		if err != nil {
+			return nil, fmt.Errorf("contact %s: %w", id, err)
+		}
+		if c == nil {
+			return nil, fmt.Errorf("contact %s: not found", id)
+		}
+		cache[id] = c
+		contacts = append(contacts, *c)
+	}
+
+	return contacts, nil
 }

--- a/internal/usecase/print_usecase_test.go
+++ b/internal/usecase/print_usecase_test.go
@@ -10,6 +10,7 @@ import (
 
 type stubContactRepo struct {
 	findByIDCalls int
+	contacts      map[string]entity.Contact
 }
 
 func (r *stubContactRepo) FindAll(groupID string) ([]entity.Contact, error) {
@@ -18,6 +19,10 @@ func (r *stubContactRepo) FindAll(groupID string) ([]entity.Contact, error) {
 
 func (r *stubContactRepo) FindByID(id string) (*entity.Contact, error) {
 	r.findByIDCalls++
+	if c, ok := r.contacts[id]; ok {
+		contact := c
+		return &contact, nil
+	}
 	return nil, nil
 }
 
@@ -60,12 +65,19 @@ func (r *stubSenderRepo) Delete(id string) error {
 }
 
 type stubPDFGenerator struct {
-	calls int
+	calls             int
+	detectCalls       int
+	unsupportedResult []entity.UnsupportedCharacterWarning
 }
 
 func (g *stubPDFGenerator) GenerateLabelPDF(job entity.PrintJob, contacts []entity.Contact, sender *entity.Sender) ([]byte, error) {
 	g.calls++
 	return []byte("%PDF-1.4\n"), nil
+}
+
+func (g *stubPDFGenerator) DetectUnsupportedCharacters(job entity.PrintJob, contacts []entity.Contact) ([]entity.UnsupportedCharacterWarning, error) {
+	g.detectCalls++
+	return g.unsupportedResult, nil
 }
 
 type stubPrinter struct{}
@@ -101,5 +113,67 @@ func TestGenerateLabelPDF_RejectsMismatchedLabelImageCount(t *testing.T) {
 	}
 	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
 		t.Fatalf("output file should not exist, statErr=%v", statErr)
+	}
+}
+
+func TestCheckUnsupportedCharacters_ReturnsWarnings(t *testing.T) {
+	contactRepo := &stubContactRepo{
+		contacts: map[string]entity.Contact{
+			"c1": {ID: "c1", FamilyName: "髙橋", GivenName: "太郎"},
+		},
+	}
+	senderRepo := &stubSenderRepo{}
+	pdfGen := &stubPDFGenerator{
+		unsupportedResult: []entity.UnsupportedCharacterWarning{
+			{
+				ContactID:   "c1",
+				ContactName: "髙橋太郎",
+				Characters:  []string{"髙"},
+			},
+		},
+	}
+	uc := NewPrintUseCase(contactRepo, senderRepo, pdfGen, &stubPrinter{})
+
+	warnings, err := uc.CheckUnsupportedCharacters(entity.PrintJob{
+		ContactIDs: []string{"c1"},
+	})
+	if err != nil {
+		t.Fatalf("CheckUnsupportedCharacters: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warning count = %d, want 1", len(warnings))
+	}
+	if warnings[0].ContactID != "c1" {
+		t.Fatalf("warning contact ID = %q, want c1", warnings[0].ContactID)
+	}
+	if warnings[0].Characters[0] != "髙" {
+		t.Fatalf("warning character = %q, want 髙", warnings[0].Characters[0])
+	}
+	if contactRepo.findByIDCalls != 1 {
+		t.Fatalf("FindByID calls = %d, want 1", contactRepo.findByIDCalls)
+	}
+	if pdfGen.detectCalls != 1 {
+		t.Fatalf("DetectUnsupportedCharacters calls = %d, want 1", pdfGen.detectCalls)
+	}
+}
+
+func TestCheckUnsupportedCharacters_EmptyContactIDs(t *testing.T) {
+	contactRepo := &stubContactRepo{}
+	senderRepo := &stubSenderRepo{}
+	pdfGen := &stubPDFGenerator{}
+	uc := NewPrintUseCase(contactRepo, senderRepo, pdfGen, &stubPrinter{})
+
+	warnings, err := uc.CheckUnsupportedCharacters(entity.PrintJob{})
+	if err != nil {
+		t.Fatalf("CheckUnsupportedCharacters: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warning count = %d, want 0", len(warnings))
+	}
+	if contactRepo.findByIDCalls != 0 {
+		t.Fatalf("FindByID calls = %d, want 0", contactRepo.findByIDCalls)
+	}
+	if pdfGen.detectCalls != 0 {
+		t.Fatalf("DetectUnsupportedCharacters calls = %d, want 0", pdfGen.detectCalls)
 	}
 }


### PR DESCRIPTION
## 概要
- 印刷前に未対応文字を検知するバックエンドAPIを追加
- PDFフォントの cmap 解析で文字対応可否を判定し、連絡先ごとに未対応文字を返却
- 印刷確認ダイアログで未対応文字の警告を表示し、チェック中は印刷操作を一時無効化

## 変更内容
- `PrintUseCase` に未対応文字チェック処理を追加
- `App.CheckUnsupportedCharacters` を追加し Wails バインディングを更新
- `pdf.Generator` に `DetectUnsupportedCharacters` を追加
- `PrintConfirmDialog` に印刷前チェックと警告UIを追加
- 関連する Go テストを追加

## 動作確認
- `go test ./...`
- `npm --prefix frontend run build`
- `npm --prefix frontend run test:run`

Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* **印刷前の文字検証機能** - 印刷ジョブに非対応文字が含まれている場合、事前に警告を表示します。ユーザーはPDF保存または印刷を続行する前に非対応文字の詳細を確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->