### PR TITLE
Issue #61: 長い氏名・連名でも崩れない自動レイアウトを追加

### DIFF
--- a/frontend/src/lib/labelRenderer.test.ts
+++ b/frontend/src/lib/labelRenderer.test.ts
@@ -129,4 +129,54 @@ describe('renderLabelTextLayer', () => {
       }),
     )
   })
+
+  it('縦書きで長い氏名は自動で複数列に分割する', () => {
+    const ctx = createMockContext()
+
+    renderLabelTextLayer(
+      ctx as unknown as CanvasRenderingContext2D,
+      {
+        ...baseContact,
+        familyName: '山田太郎次郎三郎四郎五郎六郎七郎八郎九郎十郎',
+        givenName: '',
+      },
+      baseTemplate,
+      { pxPerMm: 1, showBackground: false, showBorder: false },
+    )
+
+    expect(drawVerticalBlock).toHaveBeenCalledTimes(2)
+    const nameCall = vi.mocked(drawVerticalBlock).mock.calls[0][0]
+    expect(nameCall.lines.length).toBeGreaterThan(1)
+  })
+
+  it('横書きで連名は自動で改行して描画する', () => {
+    const ctx = createMockContext()
+    const fillText = vi.mocked(ctx.fillText)
+
+    renderLabelTextLayer(
+      ctx as unknown as CanvasRenderingContext2D,
+      {
+        ...baseContact,
+        familyName: '山田太郎・山田花子',
+        givenName: '',
+      },
+      {
+        ...baseTemplate,
+        orientation: 'horizontal',
+        labelWidth: 23,
+        labelHeight: 30,
+        recipient: {
+          ...baseTemplate.recipient,
+          nameX: 5,
+          nameY: 4,
+          addressY: 16,
+        },
+      },
+      { pxPerMm: 1, showBackground: false, showBorder: false },
+    )
+
+    const renderedTexts = fillText.mock.calls.map(([text]) => text)
+    expect(renderedTexts[0]).toBe('山田太郎・')
+    expect(renderedTexts[1]).toBe('山田花子　様')
+  })
 })

--- a/frontend/src/lib/labelRenderer.ts
+++ b/frontend/src/lib/labelRenderer.ts
@@ -32,6 +32,271 @@ export function resolveFontFamily(
     : '"Hiragino Mincho ProN", "Yu Mincho", "MS PMincho", serif'
 }
 
+const JOINT_NAME_SEPARATOR = /[・･/／&＆]/
+
+const NAME_AUTO_LAYOUT_RULES = {
+  horizontalMinFontPt: 7,
+  horizontalSplitThresholdChars: 12,
+  horizontalLineHeight: 1.35,
+  horizontalRightPaddingMm: 2,
+  horizontalBottomPaddingMm: 2,
+  horizontalAddressGapMm: 1.2,
+  horizontalGlyphWidthRatio: 0.95,
+  verticalMinFontPt: 6,
+  verticalBottomPaddingMm: 2,
+  verticalLeftPaddingMm: 2,
+  verticalAddressGapMm: 1.2,
+  verticalColumnGapRatio: 0.2,
+  verticalCharHeightRatio: 1.05,
+  maxVerticalColumns: 3,
+} as const
+
+interface HorizontalNameLayout {
+  lines: string[]
+  fontPt: number
+  lineHeightMm: number
+}
+
+interface VerticalNameLayout {
+  columns: string[]
+  fontPt: number
+}
+
+function ptToMm(valuePt: number): number {
+  return valuePt * PT_TO_MM
+}
+
+function estimateTextUnits(text: string): number {
+  let units = 0
+  for (const ch of [...text]) {
+    if (ch === ' ' || ch === '\u3000') {
+      units += 0.55
+    } else if (/^[\u0020-\u007E\uFF61-\uFF9F]$/.test(ch)) {
+      units += 0.55
+    } else if (ch === 'ー' || ch === 'ｰ' || ch === '-') {
+      units += 0.8
+    } else {
+      units += 1
+    }
+  }
+  return units
+}
+
+function estimateLineWidthMm(text: string, fontPt: number): number {
+  return estimateTextUnits(text) * ptToMm(fontPt) * NAME_AUTO_LAYOUT_RULES.horizontalGlyphWidthRatio
+}
+
+function listFontCandidates(basePt: number, minPt: number): number[] {
+  const floor = Math.min(basePt, minPt)
+  if (basePt <= floor + 1e-6) return [basePt]
+
+  const out: number[] = []
+  for (let pt = basePt; pt >= floor-1e-6; pt -= 0.5) {
+    out.push(Math.round(pt * 10) / 10)
+  }
+  if (Math.abs(out[out.length - 1] - floor) > 1e-6) {
+    out.push(floor)
+  }
+  return [...new Set(out)]
+}
+
+function splitEvenly(text: string, pieces: number): string[] {
+  const chars = [...text]
+  if (pieces <= 1 || chars.length <= 1) return [text]
+
+  const bucketCount = Math.min(pieces, chars.length)
+  const out: string[] = []
+  let index = 0
+  for (let i = 0; i < bucketCount; i++) {
+    const remainingChars = chars.length - index
+    const remainingBuckets = bucketCount - i
+    const take = Math.ceil(remainingChars / remainingBuckets)
+    out.push(chars.slice(index, index + take).join(''))
+    index += take
+  }
+  return out.filter(Boolean)
+}
+
+function splitJointNameBody(nameBody: string): string[] {
+  const out: string[] = []
+  let buf = ''
+  for (const ch of [...nameBody]) {
+    if (JOINT_NAME_SEPARATOR.test(ch)) {
+      if (buf) {
+        out.push(`${buf}${ch}`)
+        buf = ''
+      }
+      continue
+    }
+    buf += ch
+  }
+  if (buf) out.push(buf)
+  return out.length >= 2 ? out : []
+}
+
+function buildHorizontalNameCandidates(contact: Contact, honorific: string): string[][] {
+  const nameBody = `${contact.familyName}${contact.givenName}`
+  const defaultNameLine = `${nameBody}\u3000${honorific}`
+  const company = contact.company.trim()
+  const department = contact.department.trim()
+  const orgLines = [company, department].filter(Boolean)
+
+  let splitNameLines: string[] = [defaultNameLine]
+  const jointParts = splitJointNameBody(nameBody)
+  if (jointParts.length >= 2) {
+    splitNameLines = [...jointParts]
+    splitNameLines[splitNameLines.length - 1] = `${splitNameLines[splitNameLines.length - 1]}\u3000${honorific}`
+  } else if ([...nameBody].length >= NAME_AUTO_LAYOUT_RULES.horizontalSplitThresholdChars) {
+    const [first, second] = splitEvenly(nameBody, 2)
+    if (first && second) {
+      splitNameLines = [first, `${second}\u3000${honorific}`]
+    }
+  }
+
+  const mergedOrgLines = orgLines.length > 1 ? [orgLines.join(' ')] : orgLines
+
+  const keys = new Set<string>()
+  const candidates: string[][] = []
+  const add = (lines: string[]) => {
+    const normalized = lines.filter(Boolean)
+    if (normalized.length === 0) return
+    const key = normalized.join('\n')
+    if (keys.has(key)) return
+    keys.add(key)
+    candidates.push(normalized)
+  }
+
+  add([...orgLines, defaultNameLine])
+  add([...orgLines, ...splitNameLines])
+  add([...mergedOrgLines, defaultNameLine])
+  add([...mergedOrgLines, ...splitNameLines])
+  add([defaultNameLine])
+  add(splitNameLines)
+
+  return candidates
+}
+
+function computeHorizontalNameLayout(contact: Contact, tpl: Template): HorizontalNameLayout {
+  const rc = tpl.recipient
+  const honorific = contact.honorific || '様'
+  const candidates = buildHorizontalNameCandidates(contact, honorific)
+  const baseFontPt = rc.nameFont
+  const minFontPt = Math.min(baseFontPt, NAME_AUTO_LAYOUT_RULES.horizontalMinFontPt)
+  const lineHeightRatio = NAME_AUTO_LAYOUT_RULES.horizontalLineHeight
+
+  const availableWidthMm = Math.max(10, tpl.labelWidth - rc.nameX - NAME_AUTO_LAYOUT_RULES.horizontalRightPaddingMm)
+  let availableHeightMm = tpl.labelHeight - rc.nameY - NAME_AUTO_LAYOUT_RULES.horizontalBottomPaddingMm
+  if (rc.addressY > rc.nameY) {
+    availableHeightMm = Math.min(
+      availableHeightMm,
+      rc.addressY - rc.nameY - NAME_AUTO_LAYOUT_RULES.horizontalAddressGapMm,
+    )
+  }
+  availableHeightMm = Math.max(availableHeightMm, ptToMm(minFontPt) * lineHeightRatio)
+
+  const fontCandidates = listFontCandidates(baseFontPt, minFontPt)
+  for (const lines of candidates) {
+    for (const fontPt of fontCandidates) {
+      const lineHeightMm = ptToMm(fontPt) * lineHeightRatio
+      const requiredHeightMm = lineHeightMm * lines.length
+      if (requiredHeightMm > availableHeightMm + 1e-6) {
+        continue
+      }
+      const maxLineWidthMm = lines.reduce(
+        (max, line) => Math.max(max, estimateLineWidthMm(line, fontPt)),
+        0,
+      )
+      if (maxLineWidthMm <= availableWidthMm + 1e-6) {
+        return { lines, fontPt, lineHeightMm }
+      }
+    }
+  }
+
+  const fallbackLines = candidates[candidates.length - 1] ?? [`${contact.familyName}${contact.givenName}\u3000${honorific}`]
+  return {
+    lines: fallbackLines,
+    fontPt: minFontPt,
+    lineHeightMm: ptToMm(minFontPt) * lineHeightRatio,
+  }
+}
+
+function buildVerticalNameCandidates(nameBody: string, honorific: string): string[][] {
+  const fullName = `${nameBody}${honorific}`
+  const keys = new Set<string>()
+  const candidates: string[][] = []
+  const add = (columns: string[]) => {
+    const normalized = columns.filter(Boolean)
+    if (normalized.length === 0) return
+    const key = normalized.join('\n')
+    if (keys.has(key)) return
+    keys.add(key)
+    candidates.push(normalized)
+  }
+
+  add([fullName])
+
+  const jointParts = splitJointNameBody(nameBody)
+  if (jointParts.length >= 2) {
+    const columns = [...jointParts].slice(0, NAME_AUTO_LAYOUT_RULES.maxVerticalColumns)
+    if (jointParts.length > NAME_AUTO_LAYOUT_RULES.maxVerticalColumns) {
+      columns[columns.length - 1] += jointParts.slice(NAME_AUTO_LAYOUT_RULES.maxVerticalColumns).join('')
+    }
+    columns[columns.length - 1] = `${columns[columns.length - 1]}${honorific}`
+    add(columns)
+  }
+
+  for (let cols = 2; cols <= NAME_AUTO_LAYOUT_RULES.maxVerticalColumns; cols++) {
+    const columns = splitEvenly(nameBody, cols)
+    if (columns.length <= 1) continue
+    columns[columns.length - 1] = `${columns[columns.length - 1]}${honorific}`
+    add(columns)
+  }
+
+  return candidates
+}
+
+function computeVerticalNameLayout(contact: Contact, tpl: Template): VerticalNameLayout {
+  const rc = tpl.recipient
+  const honorific = contact.honorific || '様'
+  const nameBody = `${contact.familyName}${contact.givenName}`
+  const candidates = buildVerticalNameCandidates(nameBody, honorific)
+
+  const baseFontPt = rc.nameFont
+  const minFontPt = Math.min(baseFontPt, NAME_AUTO_LAYOUT_RULES.verticalMinFontPt)
+  const fontCandidates = listFontCandidates(baseFontPt, minFontPt)
+  const availableHeightMm = Math.max(
+    ptToMm(minFontPt) * NAME_AUTO_LAYOUT_RULES.verticalCharHeightRatio,
+    tpl.labelHeight - rc.nameY - NAME_AUTO_LAYOUT_RULES.verticalBottomPaddingMm,
+  )
+
+  let leftLimitMm = NAME_AUTO_LAYOUT_RULES.verticalLeftPaddingMm
+  if (rc.addressX > 0 && rc.addressX < rc.nameX) {
+    leftLimitMm = Math.max(
+      leftLimitMm,
+      rc.addressX + ptToMm(rc.addressFont) * 1.2 + NAME_AUTO_LAYOUT_RULES.verticalAddressGapMm,
+    )
+  }
+  const availableWidthMm = Math.max(ptToMm(minFontPt), rc.nameX - leftLimitMm)
+
+  for (const columns of candidates) {
+    const maxChars = columns.reduce((max, line) => Math.max(max, [...line].length), 0)
+    if (maxChars <= 0) continue
+
+    for (const fontPt of fontCandidates) {
+      const fontMm = ptToMm(fontPt)
+      const colGap = fontMm * NAME_AUTO_LAYOUT_RULES.verticalColumnGapRatio
+      const requiredWidthMm = fontMm * columns.length + colGap * (columns.length - 1)
+      const requiredHeightMm = maxChars * fontMm * NAME_AUTO_LAYOUT_RULES.verticalCharHeightRatio
+      if (requiredWidthMm <= availableWidthMm + 1e-6 && requiredHeightMm <= availableHeightMm + 1e-6) {
+        return { columns, fontPt }
+      }
+    }
+  }
+
+  const fallbackColumns = candidates[candidates.length - 1] ?? [`${nameBody}${honorific}`]
+  return { columns: fallbackColumns, fontPt: minFontPt }
+}
+
 interface RenderLabelTextLayerOptions {
   pxPerMm: number
   showBackground?: boolean
@@ -110,9 +375,8 @@ function renderVerticalLabel(
 ): void {
   {
     const rc = tpl.recipient
-    const nameFontPx = ptToPx(rc.nameFont, pxPerMm)
-    const honorific = contact.honorific || '様'
-    const fullName = `${contact.familyName}${contact.givenName}${honorific}`
+    const nameLayout = computeVerticalNameLayout(contact, tpl)
+    const nameFontPx = ptToPx(nameLayout.fontPt, pxPerMm)
 
     ctx.fillStyle = '#111827'
     const nameWeight = rc.nameBold ? 'bold' : 'normal'
@@ -120,7 +384,7 @@ function renderVerticalLabel(
 
     drawVerticalBlock({
       ctx,
-      lines: [fullName],
+      lines: nameLayout.columns,
       rightX: mmToPx(rc.nameX, pxPerMm),
       topY: mmToPx(rc.nameY, pxPerMm),
       fontSize: nameFontPx,
@@ -157,15 +421,17 @@ function renderHorizontalLabel(
 ): void {
   {
     const rc = tpl.recipient
-    const nameFontPx = ptToPx(rc.nameFont, pxPerMm)
-    const honorific = contact.honorific || '様'
-    const fullName = `${contact.familyName}${contact.givenName}　${honorific}`
+    const nameLayout = computeHorizontalNameLayout(contact, tpl)
+    const nameFontPx = ptToPx(nameLayout.fontPt, pxPerMm)
+    const nameLineHeightPx = mmToPx(nameLayout.lineHeightMm, pxPerMm)
 
     ctx.fillStyle = '#111827'
     ctx.font = `${rc.nameBold ? 'bold' : 'normal'} ${nameFontPx}px ${resolveFontFamily(rc.nameFontFamily)}`
     ctx.textAlign = 'left'
     ctx.textBaseline = 'top'
-    ctx.fillText(fullName, mmToPx(rc.nameX, pxPerMm), mmToPx(rc.nameY, pxPerMm))
+    nameLayout.lines.forEach((line, i) => {
+      ctx.fillText(line, mmToPx(rc.nameX, pxPerMm), mmToPx(rc.nameY, pxPerMm) + i * nameLineHeightPx)
+    })
   }
 
   {

--- a/internal/infrastructure/pdf/label_pdf.go
+++ b/internal/infrastructure/pdf/label_pdf.go
@@ -7,9 +7,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"runtime"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/jung-kurt/gofpdf"
 	qrcode "github.com/skip2/go-qrcode"
@@ -710,6 +712,369 @@ func drawQR(pdf *gofpdf.Fpdf, qr *entity.QRConfig, pngBytes []byte, originX, ori
 	pdf.ImageOptions(imgKey, qrX, qrY, sizeMM, sizeMM, false, gofpdf.ImageOptions{ImageType: "PNG"}, 0, "")
 }
 
+const (
+	nameHorizontalMinFontPt       = 7.0
+	nameHorizontalSplitThreshold  = 12
+	nameHorizontalLineHeightRatio = 1.35
+	nameHorizontalRightPaddingMm  = 2.0
+	nameHorizontalBottomPaddingMm = 2.0
+	nameHorizontalAddressGapMm    = 1.2
+	nameHorizontalGlyphWidthRatio = 0.95
+	nameVerticalMinFontPt         = 6.0
+	nameVerticalBottomPaddingMm   = 2.0
+	nameVerticalLeftPaddingMm     = 2.0
+	nameVerticalAddressGapMm      = 1.2
+	nameVerticalColumnGapRatio    = 0.2
+	nameVerticalCharHeightRatio   = 1.05
+	nameVerticalMaxColumns        = 3
+)
+
+var jointNameSeparators = map[rune]struct{}{
+	'・': {}, '･': {}, '/': {}, '／': {}, '&': {}, '＆': {},
+}
+
+type horizontalNameLayout struct {
+	Lines       []string
+	FontPt      float64
+	LineHeightM float64
+}
+
+type verticalNameLayout struct {
+	Columns []string
+	FontPt  float64
+}
+
+func estimateTextUnits(text string) float64 {
+	units := 0.0
+	for _, ch := range text {
+		switch {
+		case ch == ' ' || ch == '\u3000':
+			units += 0.55
+		case isHalfWidthRune(ch):
+			units += 0.55
+		case ch == 'ー' || ch == 'ｰ' || ch == '-':
+			units += 0.8
+		default:
+			units += 1
+		}
+	}
+	return units
+}
+
+func isHalfWidthRune(ch rune) bool {
+	return (ch >= 0x20 && ch <= 0x7E) || (ch >= 0xFF61 && ch <= 0xFF9F)
+}
+
+func estimateLineWidthMm(text string, fontPt float64) float64 {
+	return estimateTextUnits(text) * fontPt * ptToMm * nameHorizontalGlyphWidthRatio
+}
+
+func listFontCandidates(basePt, minPt float64) []float64 {
+	floor := minPt
+	if basePt < floor {
+		floor = basePt
+	}
+	if basePt <= floor+1e-6 {
+		return []float64{basePt}
+	}
+
+	out := make([]float64, 0, int((basePt-floor)*2)+2)
+	for pt := basePt; pt >= floor-1e-6; pt -= 0.5 {
+		out = append(out, math.Round(pt*10)/10)
+	}
+	if len(out) == 0 || math.Abs(out[len(out)-1]-floor) > 1e-6 {
+		out = append(out, floor)
+	}
+
+	uniq := make([]float64, 0, len(out))
+	seen := map[float64]struct{}{}
+	for _, pt := range out {
+		if _, ok := seen[pt]; ok {
+			continue
+		}
+		seen[pt] = struct{}{}
+		uniq = append(uniq, pt)
+	}
+	return uniq
+}
+
+func splitEvenly(text string, pieces int) []string {
+	runes := []rune(text)
+	if pieces <= 1 || len(runes) <= 1 {
+		return []string{text}
+	}
+
+	bucketCount := pieces
+	if bucketCount > len(runes) {
+		bucketCount = len(runes)
+	}
+	out := make([]string, 0, bucketCount)
+	idx := 0
+	for i := 0; i < bucketCount; i++ {
+		remainingChars := len(runes) - idx
+		remainingBuckets := bucketCount - i
+		take := (remainingChars + remainingBuckets - 1) / remainingBuckets
+		out = append(out, string(runes[idx:idx+take]))
+		idx += take
+	}
+	return out
+}
+
+func splitJointNameBody(nameBody string) []string {
+	out := []string{}
+	buf := []rune{}
+	for _, ch := range nameBody {
+		if _, ok := jointNameSeparators[ch]; ok {
+			if len(buf) > 0 {
+				part := append([]rune{}, buf...)
+				part = append(part, ch)
+				out = append(out, string(part))
+				buf = buf[:0]
+			}
+			continue
+		}
+		buf = append(buf, ch)
+	}
+	if len(buf) > 0 {
+		out = append(out, string(buf))
+	}
+	if len(out) < 2 {
+		return nil
+	}
+	return out
+}
+
+func buildHorizontalNameCandidates(contact *entity.Contact, honorific string) [][]string {
+	nameBody := contact.FamilyName + contact.GivenName
+	defaultNameLine := nameBody + "\u3000" + honorific
+
+	orgLines := []string{}
+	if v := strings.TrimSpace(contact.Company); v != "" {
+		orgLines = append(orgLines, v)
+	}
+	if v := strings.TrimSpace(contact.Department); v != "" {
+		orgLines = append(orgLines, v)
+	}
+
+	splitNameLines := []string{defaultNameLine}
+	if jointParts := splitJointNameBody(nameBody); len(jointParts) >= 2 {
+		splitNameLines = append([]string{}, jointParts...)
+		splitNameLines[len(splitNameLines)-1] = splitNameLines[len(splitNameLines)-1] + "\u3000" + honorific
+	} else if utf8.RuneCountInString(nameBody) >= nameHorizontalSplitThreshold {
+		parts := splitEvenly(nameBody, 2)
+		if len(parts) == 2 {
+			splitNameLines = []string{parts[0], parts[1] + "\u3000" + honorific}
+		}
+	}
+
+	mergedOrgLines := orgLines
+	if len(orgLines) > 1 {
+		mergedOrgLines = []string{strings.Join(orgLines, " ")}
+	}
+
+	candidates := make([][]string, 0, 6)
+	seen := map[string]struct{}{}
+	add := func(lines []string) {
+		normalized := make([]string, 0, len(lines))
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+			normalized = append(normalized, line)
+		}
+		if len(normalized) == 0 {
+			return
+		}
+		key := strings.Join(normalized, "\n")
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		candidates = append(candidates, normalized)
+	}
+
+	add(append(append([]string{}, orgLines...), defaultNameLine))
+	add(append(append([]string{}, orgLines...), splitNameLines...))
+	add(append(append([]string{}, mergedOrgLines...), defaultNameLine))
+	add(append(append([]string{}, mergedOrgLines...), splitNameLines...))
+	add([]string{defaultNameLine})
+	add(splitNameLines)
+
+	return candidates
+}
+
+func computeHorizontalNameLayout(contact *entity.Contact, tmpl entity.Template, honorific string) horizontalNameLayout {
+	rec := tmpl.Recipient
+	candidates := buildHorizontalNameCandidates(contact, honorific)
+
+	baseFontPt := rec.NameFont
+	minFontPt := rec.NameFont
+	if nameHorizontalMinFontPt < minFontPt {
+		minFontPt = nameHorizontalMinFontPt
+	}
+
+	availableWidthMm := tmpl.LabelWidth - rec.NameX - nameHorizontalRightPaddingMm
+	if availableWidthMm < 10 {
+		availableWidthMm = 10
+	}
+	availableHeightMm := tmpl.LabelHeight - rec.NameY - nameHorizontalBottomPaddingMm
+	if rec.AddressY > rec.NameY {
+		availableHeightMm = math.Min(availableHeightMm, rec.AddressY-rec.NameY-nameHorizontalAddressGapMm)
+	}
+	minRequiredHeight := minFontPt * ptToMm * nameHorizontalLineHeightRatio
+	if availableHeightMm < minRequiredHeight {
+		availableHeightMm = minRequiredHeight
+	}
+
+	fontCandidates := listFontCandidates(baseFontPt, minFontPt)
+	for _, lines := range candidates {
+		for _, fontPt := range fontCandidates {
+			lineHeightMm := fontPt * ptToMm * nameHorizontalLineHeightRatio
+			if lineHeightMm*float64(len(lines)) > availableHeightMm+1e-6 {
+				continue
+			}
+			maxLineWidthMm := 0.0
+			for _, line := range lines {
+				w := estimateLineWidthMm(line, fontPt)
+				if w > maxLineWidthMm {
+					maxLineWidthMm = w
+				}
+			}
+			if maxLineWidthMm <= availableWidthMm+1e-6 {
+				return horizontalNameLayout{
+					Lines:       lines,
+					FontPt:      fontPt,
+					LineHeightM: lineHeightMm,
+				}
+			}
+		}
+	}
+
+	fallback := []string{contact.FamilyName + contact.GivenName + "\u3000" + honorific}
+	if len(candidates) > 0 {
+		fallback = candidates[len(candidates)-1]
+	}
+	return horizontalNameLayout{
+		Lines:       fallback,
+		FontPt:      minFontPt,
+		LineHeightM: minFontPt * ptToMm * nameHorizontalLineHeightRatio,
+	}
+}
+
+func buildVerticalNameCandidates(nameBody, honorific string) [][]string {
+	fullName := nameBody + honorific
+	candidates := make([][]string, 0, nameVerticalMaxColumns+1)
+	seen := map[string]struct{}{}
+	add := func(cols []string) {
+		normalized := make([]string, 0, len(cols))
+		for _, line := range cols {
+			if line == "" {
+				continue
+			}
+			normalized = append(normalized, line)
+		}
+		if len(normalized) == 0 {
+			return
+		}
+		key := strings.Join(normalized, "\n")
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		candidates = append(candidates, normalized)
+	}
+
+	add([]string{fullName})
+
+	if joint := splitJointNameBody(nameBody); len(joint) >= 2 {
+		cols := append([]string{}, joint...)
+		if len(cols) > nameVerticalMaxColumns {
+			merged := append([]string{}, cols[:nameVerticalMaxColumns-1]...)
+			merged = append(merged, strings.Join(cols[nameVerticalMaxColumns-1:], ""))
+			cols = merged
+		}
+		cols[len(cols)-1] = cols[len(cols)-1] + honorific
+		add(cols)
+	}
+
+	for n := 2; n <= nameVerticalMaxColumns; n++ {
+		cols := splitEvenly(nameBody, n)
+		if len(cols) <= 1 {
+			continue
+		}
+		cols[len(cols)-1] = cols[len(cols)-1] + honorific
+		add(cols)
+	}
+
+	return candidates
+}
+
+func computeVerticalNameLayout(contact *entity.Contact, tmpl entity.Template, honorific string) verticalNameLayout {
+	rec := tmpl.Recipient
+	nameBody := contact.FamilyName + contact.GivenName
+	candidates := buildVerticalNameCandidates(nameBody, honorific)
+
+	baseFontPt := rec.NameFont
+	minFontPt := rec.NameFont
+	if nameVerticalMinFontPt < minFontPt {
+		minFontPt = nameVerticalMinFontPt
+	}
+	fontCandidates := listFontCandidates(baseFontPt, minFontPt)
+
+	availableHeightMm := tmpl.LabelHeight - rec.NameY - nameVerticalBottomPaddingMm
+	minRequiredHeight := minFontPt * ptToMm * nameVerticalCharHeightRatio
+	if availableHeightMm < minRequiredHeight {
+		availableHeightMm = minRequiredHeight
+	}
+
+	leftLimitMm := nameVerticalLeftPaddingMm
+	if rec.AddressX > 0 && rec.AddressX < rec.NameX {
+		limit := rec.AddressX + rec.AddressFont*ptToMm*1.2 + nameVerticalAddressGapMm
+		if limit > leftLimitMm {
+			leftLimitMm = limit
+		}
+	}
+	availableWidthMm := rec.NameX - leftLimitMm
+	minRequiredWidth := minFontPt * ptToMm
+	if availableWidthMm < minRequiredWidth {
+		availableWidthMm = minRequiredWidth
+	}
+
+	for _, columns := range candidates {
+		maxChars := 0
+		for _, line := range columns {
+			if n := utf8.RuneCountInString(line); n > maxChars {
+				maxChars = n
+			}
+		}
+		if maxChars <= 0 {
+			continue
+		}
+
+		for _, fontPt := range fontCandidates {
+			fontMm := fontPt * ptToMm
+			colGap := fontMm * nameVerticalColumnGapRatio
+			requiredWidthMm := fontMm*float64(len(columns)) + colGap*float64(len(columns)-1)
+			requiredHeightMm := float64(maxChars) * fontMm * nameVerticalCharHeightRatio
+			if requiredWidthMm <= availableWidthMm+1e-6 && requiredHeightMm <= availableHeightMm+1e-6 {
+				return verticalNameLayout{
+					Columns: columns,
+					FontPt:  fontPt,
+				}
+			}
+		}
+	}
+
+	fallback := []string{nameBody + honorific}
+	if len(candidates) > 0 {
+		fallback = candidates[len(candidates)-1]
+	}
+	return verticalNameLayout{
+		Columns: fallback,
+		FontPt:  minFontPt,
+	}
+}
+
 // drawLabel renders postal code, recipient and sender onto a single label cell.
 func drawLabel(
 	pdf *gofpdf.Fpdf,
@@ -769,17 +1134,6 @@ func drawLabel(
 		honorific = "様"
 	}
 
-	var nameLines []string
-	if contact.Company != "" {
-		nameLines = append(nameLines, contact.Company)
-		if contact.Department != "" {
-			nameLines = append(nameLines, contact.Department)
-		}
-	}
-	// 横書きはアプリ同様に全角スペースで姓名と敬称を区切る
-	fullName := contact.FamilyName + contact.GivenName + "\u3000" + honorific
-	nameLines = append(nameLines, fullName)
-
 	// ── 住所を2行(横書き) / 2カラム(縦書き)に分割 ─────────────────────────
 	// アプリプレビューと同じく「都道府県+市区町村」/「番地+建物名」で分割する。
 	addrLine1 := contact.Prefecture + contact.City
@@ -796,12 +1150,10 @@ func drawLabel(
 	}
 
 	if tmpl.Orientation == "vertical" {
-		// 縦書き: プレビュー drawVerticalBlock と同じ右端基準・列幅
-		setFont(rec.NameFont, rec.NameFontFamily)
-		nameFontMm := rec.NameFont * ptToMm
-		// 縦書きは「氏名+敬称」を同一列で描画
-		drawVerticalBlockPDF(pdf, []string{contact.FamilyName + contact.GivenName + honorific},
-			ox+rec.NameX, oy+rec.NameY, nameFontMm)
+		// 縦書き: 長文や連名は自動で縮小/列分割して枠内に収める
+		nameLayout := computeVerticalNameLayout(contact, tmpl, honorific)
+		setFont(nameLayout.FontPt, rec.NameFontFamily)
+		drawVerticalBlockPDF(pdf, nameLayout.Columns, ox+rec.NameX, oy+rec.NameY, nameLayout.FontPt*ptToMm)
 
 		setFont(rec.AddressFont, rec.AddressFontFamily)
 		addrFontMm := rec.AddressFont * ptToMm
@@ -812,13 +1164,12 @@ func drawLabel(
 		}
 		drawVerticalBlockPDF(pdf, kanjiAddrLines, ox+rec.AddressX, oy+rec.AddressY, addrFontMm)
 	} else {
-		// 横書き: 行高をプレビューと同じ pt→mm 変換で計算
-		setFont(rec.NameFont, rec.NameFontFamily)
-		nameFontMm := rec.NameFont * ptToMm
-		nameLineH := nameFontMm * 1.4 // プレビューの nameFont は単一行なので余裕を持たせる
-		for i, line := range nameLines {
-			pdf.SetXY(ox+rec.NameX, oy+rec.NameY+float64(i)*nameLineH)
-			pdf.CellFormat(0, nameLineH, line, "", 0, "L", false, 0, "")
+		// 横書き: 長文や連名は自動で縮小/改行し、優先順で行構成を調整する
+		nameLayout := computeHorizontalNameLayout(contact, tmpl, honorific)
+		setFont(nameLayout.FontPt, rec.NameFontFamily)
+		for i, line := range nameLayout.Lines {
+			pdf.SetXY(ox+rec.NameX, oy+rec.NameY+float64(i)*nameLayout.LineHeightM)
+			pdf.CellFormat(0, nameLayout.LineHeightM, line, "", 0, "L", false, 0, "")
 		}
 
 		setFont(rec.AddressFont, rec.AddressFontFamily)

--- a/internal/infrastructure/pdf/label_pdf_test.go
+++ b/internal/infrastructure/pdf/label_pdf_test.go
@@ -3,6 +3,8 @@ package pdf
 import (
 	"os"
 	"testing"
+
+	"atena-label/internal/entity"
 )
 
 // TestJapaneseCmapScoreWithSongti verifies that the Traditional Chinese face
@@ -61,6 +63,62 @@ func TestExtractTTFFromTTCRoundtrip(t *testing.T) {
 		t.Fatal("empty font bytes from validateFontBytes")
 	}
 	t.Logf("Font bytes: %d", len(fb))
+}
+
+func TestComputeVerticalNameLayoutSplitsLongName(t *testing.T) {
+	contact := &entity.Contact{
+		FamilyName: "山田太郎次郎三郎四郎五郎六郎七郎八郎九郎十郎",
+		GivenName:  "",
+		Honorific:  "様",
+	}
+	tmpl := entity.Template{
+		LabelWidth:  86.4,
+		LabelHeight: 42.3,
+		Recipient: entity.TextConfig{
+			NameX:       79,
+			NameY:       8,
+			NameFont:    13,
+			AddressX:    69,
+			AddressY:    8,
+			AddressFont: 8.5,
+		},
+	}
+
+	layout := computeVerticalNameLayout(contact, tmpl, "様")
+	if len(layout.Columns) < 2 {
+		t.Fatalf("expected long name to be split into multiple columns, got %v", layout.Columns)
+	}
+	if layout.FontPt > tmpl.Recipient.NameFont {
+		t.Fatalf("font size must not increase (got %.1f > %.1f)", layout.FontPt, tmpl.Recipient.NameFont)
+	}
+}
+
+func TestComputeHorizontalNameLayoutSplitsJointName(t *testing.T) {
+	contact := &entity.Contact{
+		FamilyName: "山田太郎・山田花子",
+		GivenName:  "",
+		Honorific:  "様",
+	}
+	tmpl := entity.Template{
+		LabelWidth:  23,
+		LabelHeight: 30,
+		Recipient: entity.TextConfig{
+			NameX:       5,
+			NameY:       4,
+			NameFont:    12,
+			AddressX:    5,
+			AddressY:    16,
+			AddressFont: 8.5,
+		},
+	}
+
+	layout := computeHorizontalNameLayout(contact, tmpl, "様")
+	if len(layout.Lines) < 2 {
+		t.Fatalf("expected joint name to wrap, got %v", layout.Lines)
+	}
+	if layout.Lines[0] != "山田太郎・" || layout.Lines[1] != "山田花子　様" {
+		t.Fatalf("unexpected wrapped lines: %v", layout.Lines)
+	}
 }
 
 func readUint32BE(b []byte) uint32 {


### PR DESCRIPTION
## 概要
- 長文氏名・連名での宛名崩れを防ぐ自動レイアウトを追加
- プレビュー/印刷スナップショットに同一ロジックを適用
- PDFフォールバック描画にも同等ロジックを適用
- フロント/Go両方で長文・連名ケースの回帰テストを追加

## 主な変更
- `frontend/src/lib/labelRenderer.ts`
  - 宛名の自動縮小・改行/列分割ロジックを追加
  - 最小フォントや優先ルールを定数化
- `internal/infrastructure/pdf/label_pdf.go`
  - フォールバック描画でも同じ自動レイアウトを実装
- `frontend/src/lib/labelRenderer.test.ts`
  - 長文縦書き分割・連名横書き改行のテスト追加
- `internal/infrastructure/pdf/label_pdf_test.go`
  - 自動レイアウト計算のテスト追加

## テスト
- `go test ./...`
- `npm --prefix frontend run test:run`

Closes #61