### PR TITLE
[Issue #63] 住所の新表記正規化（旧住所→新住所）一括更新を追加

### DIFF
--- a/app.go
+++ b/app.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -25,6 +26,7 @@ type App struct {
 	ctx                 context.Context
 	contactUseCase      *usecase.ContactUseCase
 	contactYearStatusUC *usecase.ContactYearStatusUseCase
+	addressNormUseCase  *usecase.AddressNormalizationUseCase
 	csvUseCase          *usecase.CSVUseCase
 	groupUseCase        *usecase.GroupUseCase
 	watermarkUseCase    *usecase.WatermarkUseCase
@@ -35,6 +37,13 @@ type App struct {
 	printHistoryUseCase *usecase.PrintHistoryUseCase
 	db                  *sql.DB
 	dbPath              string
+	normMu              sync.Mutex
+	lastNormBatch       *addressNormalizationRollbackBatch
+}
+
+type addressNormalizationRollbackBatch struct {
+	BatchID  string
+	Contacts []entity.Contact
 }
 
 // NewApp creates a new App application struct
@@ -42,6 +51,7 @@ func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.Cont
 	return &App{
 		contactUseCase:      contactUC,
 		contactYearStatusUC: contactYearStatusUC,
+		addressNormUseCase:  usecase.NewAddressNormalizationUseCase(postalRepo),
 		csvUseCase:          csvUC,
 		groupUseCase:        groupUC,
 		watermarkUseCase:    watermarkUC,
@@ -105,6 +115,144 @@ func (a *App) SearchContacts(query string) ([]entity.Contact, error) {
 		return nil, fmt.Errorf("SearchContacts: %w", err)
 	}
 	return contacts, nil
+}
+
+// GetAddressNormalizationPreview returns normalization candidates derived from postal code master data.
+func (a *App) GetAddressNormalizationPreview() (entity.AddressNormalizationPreview, error) {
+	contacts, err := a.contactUseCase.List("")
+	if err != nil {
+		return entity.AddressNormalizationPreview{}, fmt.Errorf("GetAddressNormalizationPreview: %w", err)
+	}
+
+	preview := a.addressNormUseCase.BuildPreview(contacts)
+	a.normMu.Lock()
+	if a.lastNormBatch != nil && len(a.lastNormBatch.Contacts) > 0 {
+		preview.CanRollback = true
+		preview.RollbackBatchID = a.lastNormBatch.BatchID
+	}
+	a.normMu.Unlock()
+
+	return preview, nil
+}
+
+// ApplyAddressNormalization applies selected normalization candidates and records rollback data.
+func (a *App) ApplyAddressNormalization(selections []entity.AddressNormalizationSelection) (entity.AddressNormalizationApplyResult, error) {
+	contacts, err := a.contactUseCase.List("")
+	if err != nil {
+		return entity.AddressNormalizationApplyResult{}, fmt.Errorf("ApplyAddressNormalization list contacts: %w", err)
+	}
+
+	preview := a.addressNormUseCase.BuildPreview(contacts)
+	result := entity.AddressNormalizationApplyResult{
+		Errors: []string{},
+	}
+	if len(preview.Candidates) == 0 {
+		return result, nil
+	}
+
+	selected := make(map[string]bool, len(selections))
+	useSelection := len(selections) > 0
+	for _, selection := range selections {
+		selected[selection.ContactID] = selection.Apply
+	}
+
+	rollbackContacts := make([]entity.Contact, 0, len(preview.Candidates))
+	for _, candidate := range preview.Candidates {
+		if useSelection {
+			apply, ok := selected[candidate.ContactID]
+			if !ok || !apply {
+				result.SkippedCount++
+				continue
+			}
+		}
+
+		current, getErr := a.contactUseCase.Get(candidate.ContactID)
+		if getErr != nil {
+			result.FailedCount++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: 取得失敗: %v", candidate.DisplayName, getErr))
+			continue
+		}
+		if current == nil {
+			result.FailedCount++
+			result.Errors = append(result.Errors, fmt.Sprintf("contactId=%s: 連絡先が見つかりません", candidate.ContactID))
+			continue
+		}
+
+		before := *current
+		next := before
+		next.Prefecture = candidate.After.Prefecture
+		next.City = candidate.After.City
+		next.Street = candidate.After.Street
+
+		if before.Prefecture == next.Prefecture &&
+			before.City == next.City &&
+			before.Street == next.Street {
+			result.SkippedCount++
+			continue
+		}
+
+		if _, saveErr := a.contactUseCase.Save(next); saveErr != nil {
+			result.FailedCount++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: 更新失敗: %v", candidate.DisplayName, saveErr))
+			continue
+		}
+
+		result.AppliedCount++
+		rollbackContacts = append(rollbackContacts, before)
+	}
+
+	if result.AppliedCount > 0 {
+		batchID := fmt.Sprintf("addrnorm-%d", time.Now().UnixNano())
+		result.BatchID = batchID
+		result.CanRollback = true
+
+		a.normMu.Lock()
+		a.lastNormBatch = &addressNormalizationRollbackBatch{
+			BatchID:  batchID,
+			Contacts: rollbackContacts,
+		}
+		a.normMu.Unlock()
+	}
+
+	return result, nil
+}
+
+// RollbackAddressNormalization restores the latest applied normalization batch.
+func (a *App) RollbackAddressNormalization(batchID string) (entity.AddressNormalizationRollbackResult, error) {
+	result := entity.AddressNormalizationRollbackResult{
+		Errors: []string{},
+	}
+
+	a.normMu.Lock()
+	batch := a.lastNormBatch
+	a.normMu.Unlock()
+
+	if batch == nil || len(batch.Contacts) == 0 {
+		return result, fmt.Errorf("RollbackAddressNormalization: ロールバック可能な履歴がありません")
+	}
+	if batchID != "" && batch.BatchID != batchID {
+		return result, fmt.Errorf("RollbackAddressNormalization: 指定バッチが見つかりません")
+	}
+
+	result.BatchID = batch.BatchID
+	for _, snapshot := range batch.Contacts {
+		if _, err := a.contactUseCase.Save(snapshot); err != nil {
+			result.FailedCount++
+			result.Errors = append(result.Errors, fmt.Sprintf("contactId=%s: 復元失敗: %v", snapshot.ID, err))
+			continue
+		}
+		result.RestoredCount++
+	}
+
+	if result.FailedCount == 0 {
+		a.normMu.Lock()
+		if a.lastNormBatch != nil && a.lastNormBatch.BatchID == batch.BatchID {
+			a.lastNormBatch = nil
+		}
+		a.normMu.Unlock()
+	}
+
+	return result, nil
 }
 
 // GetContactYearStatuses returns all yearly statuses in the specified year.

--- a/frontend/src/components/address/AddressNormalizationDialog.tsx
+++ b/frontend/src/components/address/AddressNormalizationDialog.tsx
@@ -81,8 +81,8 @@ export default function AddressNormalizationDialog({ onClose, onCompleted }: Pro
       const typed = applied as AddressNormalizationApplyResult
       setResult(typed)
       await onCompleted()
-      setStep('result')
       await loadPreview()
+      setStep('result')
     } catch (err) {
       console.error(err)
       setError(`一括更新に失敗しました: ${String(err)}`)
@@ -102,8 +102,8 @@ export default function AddressNormalizationDialog({ onClose, onCompleted }: Pro
       await onCompleted()
       setResult(null)
       setStep('preview')
-      setNotice(`ロールバック完了: ${typed.restoredCount}件復元しました。`)
       await loadPreview()
+      setNotice(`ロールバック完了: ${typed.restoredCount}件復元しました。`)
     } catch (err) {
       console.error(err)
       setError(`ロールバックに失敗しました: ${String(err)}`)

--- a/frontend/src/components/address/AddressNormalizationDialog.tsx
+++ b/frontend/src/components/address/AddressNormalizationDialog.tsx
@@ -1,0 +1,375 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ApplyAddressNormalization,
+  GetAddressNormalizationPreview,
+  RollbackAddressNormalization,
+} from '../../../wailsjs/go/main/App'
+import type {
+  AddressNormalizationApplyResult,
+  AddressNormalizationCandidate,
+  AddressNormalizationPreview,
+  AddressNormalizationRollbackResult,
+  AddressNormalizationSelection,
+} from '../../types'
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog'
+
+interface Props {
+  onClose: () => void
+  onCompleted: () => Promise<void>
+}
+
+type Step = 'preview' | 'confirm' | 'result'
+
+export default function AddressNormalizationDialog({ onClose, onCompleted }: Props) {
+  const [step, setStep] = useState<Step>('preview')
+  const [loading, setLoading] = useState(false)
+  const [rollingBack, setRollingBack] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [preview, setPreview] = useState<AddressNormalizationPreview | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [result, setResult] = useState<AddressNormalizationApplyResult | null>(null)
+
+  const loadPreview = async () => {
+    setLoading(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const res = await GetAddressNormalizationPreview()
+      const typed = res as AddressNormalizationPreview
+      setPreview(typed)
+      setSelectedIds(new Set((typed.candidates ?? []).map((c) => c.contactId)))
+    } catch (err) {
+      console.error(err)
+      setError(`正規化候補の取得に失敗しました: ${String(err)}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadPreview()
+  }, [])
+
+  const selectedCandidates = useMemo(() => {
+    if (!preview) return [] as AddressNormalizationCandidate[]
+    return preview.candidates.filter((candidate) => selectedIds.has(candidate.contactId))
+  }, [preview, selectedIds])
+
+  const toggleSelection = (contactId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(contactId)) {
+        next.delete(contactId)
+      } else {
+        next.add(contactId)
+      }
+      return next
+    })
+  }
+
+  const handleApply = async () => {
+    if (!preview) return
+    setLoading(true)
+    setError(null)
+    try {
+      const selections: AddressNormalizationSelection[] = preview.candidates.map((candidate) => ({
+        contactId: candidate.contactId,
+        apply: selectedIds.has(candidate.contactId),
+      }))
+      const applied = await ApplyAddressNormalization(selections)
+      const typed = applied as AddressNormalizationApplyResult
+      setResult(typed)
+      await onCompleted()
+      setStep('result')
+      await loadPreview()
+    } catch (err) {
+      console.error(err)
+      setError(`一括更新に失敗しました: ${String(err)}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleRollback = async (batchID?: string) => {
+    if (!batchID || rollingBack) return
+    setRollingBack(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const rolled = await RollbackAddressNormalization(batchID)
+      const typed = rolled as AddressNormalizationRollbackResult
+      await onCompleted()
+      setResult(null)
+      setStep('preview')
+      setNotice(`ロールバック完了: ${typed.restoredCount}件復元しました。`)
+      await loadPreview()
+    } catch (err) {
+      console.error(err)
+      setError(`ロールバックに失敗しました: ${String(err)}`)
+    } finally {
+      setRollingBack(false)
+    }
+  }
+
+  const canProceedConfirm = selectedCandidates.length > 0
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>住所正規化（旧住所→新住所）</DialogTitle>
+          <DialogClose
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+          >
+            &times;
+          </DialogClose>
+        </DialogHeader>
+
+        <div className="p-5 space-y-4">
+          {loading && (
+            <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700">
+              処理中です...
+            </div>
+          )}
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+          {notice && (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+              {notice}
+            </div>
+          )}
+
+          {step === 'preview' && preview && (
+            <>
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold text-gray-800">1. 候補プレビュー</h3>
+                <p className="text-xs text-gray-500">
+                  全連絡先: {preview.totalContacts}件 / 変換候補: {preview.convertibleCount}件 / 適用予定: {selectedCandidates.length}件
+                </p>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex gap-2 text-xs">
+                    <button
+                      onClick={() => setSelectedIds(new Set(preview.candidates.map((c) => c.contactId)))}
+                      className="rounded border border-gray-300 px-2 py-1 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
+                      disabled={preview.candidates.length === 0}
+                    >
+                      すべて適用
+                    </button>
+                    <button
+                      onClick={() => setSelectedIds(new Set())}
+                      className="rounded border border-gray-300 px-2 py-1 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
+                      disabled={preview.candidates.length === 0}
+                    >
+                      すべて除外
+                    </button>
+                  </div>
+                  {preview.canRollback && preview.rollbackBatchId && (
+                    <button
+                      onClick={() => void handleRollback(preview.rollbackBatchId)}
+                      disabled={rollingBack}
+                      className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-700 hover:bg-amber-100 disabled:opacity-50"
+                    >
+                      前回更新をロールバック
+                    </button>
+                  )}
+                </div>
+
+                {preview.candidates.length > 0 ? (
+                  <div className="overflow-auto rounded-md border border-gray-200">
+                    <table className="w-full min-w-[900px] text-xs">
+                      <thead className="bg-gray-50 text-gray-600">
+                        <tr>
+                          <th className="px-2 py-2 text-left">適用</th>
+                          <th className="px-2 py-2 text-left">連絡先</th>
+                          <th className="px-2 py-2 text-left">郵便番号</th>
+                          <th className="px-2 py-2 text-left">変更前</th>
+                          <th className="px-2 py-2 text-left">変更後</th>
+                          <th className="px-2 py-2 text-left">差分</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {preview.candidates.map((candidate) => (
+                          <tr key={candidate.contactId} className="border-t border-gray-100">
+                            <td className="px-2 py-2 align-top">
+                              <input
+                                type="checkbox"
+                                checked={selectedIds.has(candidate.contactId)}
+                                onChange={() => toggleSelection(candidate.contactId)}
+                                className="mt-0.5 h-3.5 w-3.5 accent-blue-600"
+                              />
+                            </td>
+                            <td className="px-2 py-2 align-top">{candidate.displayName || '(名称未設定)'}</td>
+                            <td className="px-2 py-2 align-top">{formatPostalCode(candidate.postalCode)}</td>
+                            <td className="px-2 py-2 align-top">{formatAddress(candidate.before)}</td>
+                            <td className="px-2 py-2 align-top">{formatAddress(candidate.after)}</td>
+                            <td className="px-2 py-2 align-top">
+                              {candidate.diffs.map((diff) => (
+                                <div key={`${candidate.contactId}-${diff.field}`}>
+                                  {fieldLabel(diff.field)}: {diff.before || '(空)'} → {diff.after || '(空)'}
+                                </div>
+                              ))}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+                    現時点で変換候補はありません。
+                  </div>
+                )}
+              </section>
+
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={onClose}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  閉じる
+                </button>
+                <button
+                  onClick={() => setStep('confirm')}
+                  disabled={!canProceedConfirm || loading}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  差分確認へ
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 'confirm' && preview && (
+            <>
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold text-gray-800">2. 差分確認</h3>
+                <p className="text-xs text-gray-500">
+                  適用対象: {selectedCandidates.length}件
+                </p>
+                <div className="overflow-auto rounded-md border border-gray-200">
+                  <table className="w-full min-w-[860px] text-xs">
+                    <thead className="bg-gray-50 text-gray-600">
+                      <tr>
+                        <th className="px-2 py-2 text-left">連絡先</th>
+                        <th className="px-2 py-2 text-left">変更前</th>
+                        <th className="px-2 py-2 text-left">変更後</th>
+                        <th className="px-2 py-2 text-left">差分</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedCandidates.map((candidate) => (
+                        <tr key={candidate.contactId} className="border-t border-gray-100">
+                          <td className="px-2 py-2 align-top">{candidate.displayName || '(名称未設定)'}</td>
+                          <td className="px-2 py-2 align-top">{formatAddress(candidate.before)}</td>
+                          <td className="px-2 py-2 align-top">{formatAddress(candidate.after)}</td>
+                          <td className="px-2 py-2 align-top">
+                            {candidate.diffs.map((diff) => (
+                              <div key={`${candidate.contactId}-confirm-${diff.field}`}>
+                                {fieldLabel(diff.field)}: {diff.before || '(空)'} → {diff.after || '(空)'}
+                              </div>
+                            ))}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+
+              <div className="flex justify-between gap-2">
+                <button
+                  onClick={() => setStep('preview')}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  戻る
+                </button>
+                <button
+                  onClick={() => void handleApply()}
+                  disabled={loading || selectedCandidates.length === 0}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  確定して更新
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 'result' && result && (
+            <>
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold text-gray-800">3. 更新結果</h3>
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <Summary label="更新成功" value={result.appliedCount} />
+                  <Summary label="スキップ" value={result.skippedCount} />
+                  <Summary label="失敗" value={result.failedCount} />
+                  <Summary label="ロールバック可" value={result.canRollback ? 1 : 0} />
+                </div>
+                {result.errors.length > 0 && (
+                  <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                    <div className="font-medium">エラー詳細</div>
+                    <ul className="mt-1 list-disc pl-5 space-y-0.5">
+                      {result.errors.slice(0, 12).map((msg, idx) => (
+                        <li key={idx}>{msg}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </section>
+
+              <div className="flex justify-end gap-2">
+                {result.canRollback && result.batchId && (
+                  <button
+                    onClick={() => void handleRollback(result.batchId)}
+                    disabled={rollingBack}
+                    className="rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm text-amber-700 hover:bg-amber-100 disabled:opacity-50"
+                  >
+                    この更新をロールバック
+                  </button>
+                )}
+                <button
+                  onClick={onClose}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+                >
+                  閉じる
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function formatPostalCode(postalCode: string) {
+  if (!postalCode) return ''
+  const digits = postalCode.replace(/\D/g, '')
+  if (digits.length !== 7) return postalCode
+  return `〒${digits.slice(0, 3)}-${digits.slice(3)}`
+}
+
+function formatAddress(address: { prefecture: string; city: string; street: string }) {
+  return [address.prefecture, address.city, address.street].filter(Boolean).join('')
+}
+
+function fieldLabel(field: string) {
+  if (field === 'prefecture') return '都道府県'
+  if (field === 'city') return '市区町村'
+  if (field === 'street') return '番地'
+  return field
+}
+
+function Summary({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2">
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className="text-base font-semibold text-gray-800">{value}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -16,6 +16,7 @@ import type { Contact, ContactYearStatus, Group } from '../../types'
 import ContactEditModal from './ContactEditModal'
 import GroupManageDialog from './GroupManageDialog'
 import CSVImportWizard from './CSVImportWizard'
+import AddressNormalizationDialog from './AddressNormalizationDialog'
 
 type EditableField = 'familyName' | 'givenName' | 'honorific' | 'postalCode' | 'prefecture' | 'city' | 'street'
 type NavigationMode = 'none' | 'enter' | 'tab'
@@ -76,6 +77,7 @@ export default function ContactList() {
   // undefined = モーダル非表示, null = 新規作成, Contact = 編集
   const [showGroupManage, setShowGroupManage] = useState(false)
   const [importWizardFilePath, setImportWizardFilePath] = useState<string | null>(null)
+  const [showAddressNormalization, setShowAddressNormalization] = useState(false)
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null)
   const [inlineSaveError, setInlineSaveError] = useState<string | null>(null)
   const [savingCellKey, setSavingCellKey] = useState<string | null>(null)
@@ -874,6 +876,12 @@ export default function ContactList() {
           CSV取込
         </button>
         <button
+          onClick={() => setShowAddressNormalization(true)}
+          className="px-3 py-1.5 text-sm bg-gray-50 text-gray-700 border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
+        >
+          住所正規化
+        </button>
+        <button
           onClick={handleExport}
           className="px-3 py-1.5 text-sm bg-gray-50 text-gray-700 border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
         >
@@ -910,6 +918,13 @@ export default function ContactList() {
         <CSVImportWizard
           filePath={importWizardFilePath}
           onClose={() => setImportWizardFilePath(null)}
+          onCompleted={refreshContacts}
+        />
+      )}
+
+      {showAddressNormalization && (
+        <AddressNormalizationDialog
+          onClose={() => setShowAddressNormalization(false)}
           onCompleted={refreshContacts}
         />
       )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -170,6 +170,56 @@ export interface CSVImportExecutionResult {
   errors: string[]
 }
 
+export interface AddressNormalizationAddress {
+  prefecture: string
+  city: string
+  street: string
+}
+
+export interface AddressNormalizationDiff {
+  field: 'prefecture' | 'city' | 'street'
+  before: string
+  after: string
+}
+
+export interface AddressNormalizationCandidate {
+  contactId: string
+  displayName: string
+  postalCode: string
+  before: AddressNormalizationAddress
+  after: AddressNormalizationAddress
+  diffs: AddressNormalizationDiff[]
+}
+
+export interface AddressNormalizationPreview {
+  totalContacts: number
+  convertibleCount: number
+  candidates: AddressNormalizationCandidate[]
+  canRollback: boolean
+  rollbackBatchId?: string
+}
+
+export interface AddressNormalizationSelection {
+  contactId: string
+  apply: boolean
+}
+
+export interface AddressNormalizationApplyResult {
+  batchId?: string
+  appliedCount: number
+  skippedCount: number
+  failedCount: number
+  errors: string[]
+  canRollback: boolean
+}
+
+export interface AddressNormalizationRollbackResult {
+  batchId?: string
+  restoredCount: number
+  failedCount: number
+  errors: string[]
+}
+
 export interface PrintHistory {
   id: string
   printedAt: string

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -6,6 +6,8 @@ export function AddContactToGroup(arg1:string,arg2:string):Promise<void>;
 
 export function AnalyzeCSVImport(arg1:string,arg2:{[key: string]: number}):Promise<any>;
 
+export function ApplyAddressNormalization(arg1:Array<any>):Promise<any>;
+
 export function DeleteContacts(arg1:Array<string>):Promise<void>;
 
 export function DeleteGroup(arg1:string):Promise<void>;
@@ -25,6 +27,8 @@ export function GenerateQRPreview(arg1:entity.QRConfig):Promise<Array<number>>;
 export function CheckUnsupportedCharacters(arg1:entity.PrintJob):Promise<Array<entity.UnsupportedCharacterWarning>>;
 
 export function GetAppVersion():Promise<string>;
+
+export function GetAddressNormalizationPreview():Promise<any>;
 
 export function GetCSVImportPlan(arg1:string):Promise<any>;
 
@@ -63,6 +67,8 @@ export function OpenCSVFileDialog():Promise<string>;
 export function PrintPDF(arg1:string):Promise<void>;
 
 export function RemoveContactFromGroup(arg1:string,arg2:string):Promise<void>;
+
+export function RollbackAddressNormalization(arg1:string):Promise<any>;
 
 export function SaveCSVFileDialog(arg1:string):Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -10,6 +10,10 @@ export function AnalyzeCSVImport(arg1, arg2) {
   return window['go']['main']['App']['AnalyzeCSVImport'](arg1, arg2);
 }
 
+export function ApplyAddressNormalization(arg1) {
+  return window['go']['main']['App']['ApplyAddressNormalization'](arg1);
+}
+
 export function DeleteContacts(arg1) {
   return window['go']['main']['App']['DeleteContacts'](arg1);
 }
@@ -48,6 +52,10 @@ export function CheckUnsupportedCharacters(arg1) {
 
 export function GetAppVersion() {
   return window['go']['main']['App']['GetAppVersion']();
+}
+
+export function GetAddressNormalizationPreview() {
+  return window['go']['main']['App']['GetAddressNormalizationPreview']();
 }
 
 export function GetCSVImportPlan(arg1) {
@@ -124,6 +132,10 @@ export function PrintPDF(arg1) {
 
 export function RemoveContactFromGroup(arg1, arg2) {
   return window['go']['main']['App']['RemoveContactFromGroup'](arg1, arg2);
+}
+
+export function RollbackAddressNormalization(arg1) {
+  return window['go']['main']['App']['RollbackAddressNormalization'](arg1);
 }
 
 export function SaveCSVFileDialog(arg1) {

--- a/internal/entity/address_normalization.go
+++ b/internal/entity/address_normalization.go
@@ -1,0 +1,58 @@
+package entity
+
+// AddressNormalizationAddress is a compact address view for before/after comparison.
+type AddressNormalizationAddress struct {
+	Prefecture string `json:"prefecture"`
+	City       string `json:"city"`
+	Street     string `json:"street"`
+}
+
+// AddressNormalizationDiff represents one changed field in normalization preview.
+type AddressNormalizationDiff struct {
+	Field  string `json:"field"`
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+// AddressNormalizationCandidate is one contact that can be normalized.
+type AddressNormalizationCandidate struct {
+	ContactID   string                      `json:"contactId"`
+	DisplayName string                      `json:"displayName"`
+	PostalCode  string                      `json:"postalCode"`
+	Before      AddressNormalizationAddress `json:"before"`
+	After       AddressNormalizationAddress `json:"after"`
+	Diffs       []AddressNormalizationDiff  `json:"diffs"`
+}
+
+// AddressNormalizationPreview contains candidates and rollback status.
+type AddressNormalizationPreview struct {
+	TotalContacts    int                             `json:"totalContacts"`
+	ConvertibleCount int                             `json:"convertibleCount"`
+	Candidates       []AddressNormalizationCandidate `json:"candidates"`
+	CanRollback      bool                            `json:"canRollback"`
+	RollbackBatchID  string                          `json:"rollbackBatchId,omitempty"`
+}
+
+// AddressNormalizationSelection stores whether each candidate should be applied.
+type AddressNormalizationSelection struct {
+	ContactID string `json:"contactId"`
+	Apply     bool   `json:"apply"`
+}
+
+// AddressNormalizationApplyResult is the summary of normalization execution.
+type AddressNormalizationApplyResult struct {
+	BatchID      string   `json:"batchId,omitempty"`
+	AppliedCount int      `json:"appliedCount"`
+	SkippedCount int      `json:"skippedCount"`
+	FailedCount  int      `json:"failedCount"`
+	Errors       []string `json:"errors"`
+	CanRollback  bool     `json:"canRollback"`
+}
+
+// AddressNormalizationRollbackResult is the summary of rollback execution.
+type AddressNormalizationRollbackResult struct {
+	BatchID       string   `json:"batchId,omitempty"`
+	RestoredCount int      `json:"restoredCount"`
+	FailedCount   int      `json:"failedCount"`
+	Errors        []string `json:"errors"`
+}

--- a/internal/usecase/address_normalization_usecase.go
+++ b/internal/usecase/address_normalization_usecase.go
@@ -1,0 +1,96 @@
+package usecase
+
+import (
+	"strings"
+
+	"atena-label/internal/entity"
+	"atena-label/internal/repository"
+)
+
+type AddressNormalizationUseCase struct {
+	postalRepo repository.PostalRepository
+}
+
+func NewAddressNormalizationUseCase(postalRepo repository.PostalRepository) *AddressNormalizationUseCase {
+	return &AddressNormalizationUseCase{postalRepo: postalRepo}
+}
+
+func (uc *AddressNormalizationUseCase) BuildPreview(contacts []entity.Contact) entity.AddressNormalizationPreview {
+	candidates := make([]entity.AddressNormalizationCandidate, 0)
+	for _, contact := range contacts {
+		candidate, ok := uc.buildCandidate(contact)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+
+	return entity.AddressNormalizationPreview{
+		TotalContacts:    len(contacts),
+		ConvertibleCount: len(candidates),
+		Candidates:       candidates,
+	}
+}
+
+func (uc *AddressNormalizationUseCase) buildCandidate(contact entity.Contact) (entity.AddressNormalizationCandidate, bool) {
+	postal := strings.TrimSpace(contact.PostalCode)
+	if postal == "" {
+		return entity.AddressNormalizationCandidate{}, false
+	}
+
+	lookup, err := uc.postalRepo.Lookup(postal)
+	if err != nil || lookup == nil {
+		return entity.AddressNormalizationCandidate{}, false
+	}
+
+	before := entity.AddressNormalizationAddress{
+		Prefecture: strings.TrimSpace(contact.Prefecture),
+		City:       strings.TrimSpace(contact.City),
+		Street:     strings.TrimSpace(contact.Street),
+	}
+	after := before
+
+	if prefecture := strings.TrimSpace(lookup.Prefecture); prefecture != "" {
+		after.Prefecture = prefecture
+	}
+	if city := strings.TrimSpace(lookup.City); city != "" {
+		after.City = city
+	}
+
+	diffs := make([]entity.AddressNormalizationDiff, 0, 2)
+	if before.Prefecture != after.Prefecture {
+		diffs = append(diffs, entity.AddressNormalizationDiff{
+			Field:  "prefecture",
+			Before: before.Prefecture,
+			After:  after.Prefecture,
+		})
+	}
+	if before.City != after.City {
+		diffs = append(diffs, entity.AddressNormalizationDiff{
+			Field:  "city",
+			Before: before.City,
+			After:  after.City,
+		})
+	}
+
+	if len(diffs) == 0 {
+		return entity.AddressNormalizationCandidate{}, false
+	}
+
+	return entity.AddressNormalizationCandidate{
+		ContactID:   contact.ID,
+		DisplayName: buildDisplayName(contact),
+		PostalCode:  postal,
+		Before:      before,
+		After:       after,
+		Diffs:       diffs,
+	}, true
+}
+
+func buildDisplayName(contact entity.Contact) string {
+	fullName := strings.TrimSpace(strings.TrimSpace(contact.FamilyName) + " " + strings.TrimSpace(contact.GivenName))
+	if fullName != "" {
+		return fullName
+	}
+	return strings.TrimSpace(contact.Company)
+}

--- a/internal/usecase/address_normalization_usecase_test.go
+++ b/internal/usecase/address_normalization_usecase_test.go
@@ -1,0 +1,102 @@
+package usecase_test
+
+import (
+	"fmt"
+	"testing"
+
+	"atena-label/internal/entity"
+	"atena-label/internal/usecase"
+)
+
+type mockPostalRepo struct {
+	lookupFn func(postalCode string) (*entity.Address, error)
+}
+
+func (m *mockPostalRepo) Lookup(postalCode string) (*entity.Address, error) {
+	if m.lookupFn != nil {
+		return m.lookupFn(postalCode)
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func TestAddressNormalizationUseCase_BuildPreview(t *testing.T) {
+	repo := &mockPostalRepo{
+		lookupFn: func(postalCode string) (*entity.Address, error) {
+			switch postalCode {
+			case "1000001":
+				return &entity.Address{Prefecture: "東京都", City: "千代田区", Town: "千代田"}, nil
+			case "0600000":
+				return &entity.Address{Prefecture: "北海道", City: "札幌市中央区", Town: ""}, nil
+			default:
+				return nil, fmt.Errorf("not found")
+			}
+		},
+	}
+	uc := usecase.NewAddressNormalizationUseCase(repo)
+
+	preview := uc.BuildPreview([]entity.Contact{
+		{
+			ID:         "c1",
+			FamilyName: "山田",
+			GivenName:  "太郎",
+			PostalCode: "1000001",
+			Prefecture: "東京都",
+			City:       "千代田市",
+			Street:     "1-1-1",
+		},
+		{
+			ID:         "c2",
+			FamilyName: "佐藤",
+			GivenName:  "花子",
+			PostalCode: "1000001",
+			Prefecture: "東京都",
+			City:       "千代田区",
+			Street:     "1-2-3",
+		},
+		{
+			ID:         "c3",
+			FamilyName: "鈴木",
+			GivenName:  "次郎",
+			PostalCode: "0000000",
+			Prefecture: "旧県",
+			City:       "旧市",
+		},
+		{
+			ID:         "c4",
+			FamilyName: "高橋",
+			GivenName:  "三郎",
+			PostalCode: "0600000",
+			Prefecture: "道央県",
+			City:       "中央区",
+		},
+	})
+
+	if preview.TotalContacts != 4 {
+		t.Fatalf("TotalContacts=%d, want 4", preview.TotalContacts)
+	}
+	if preview.ConvertibleCount != 2 {
+		t.Fatalf("ConvertibleCount=%d, want 2", preview.ConvertibleCount)
+	}
+	if len(preview.Candidates) != 2 {
+		t.Fatalf("len(Candidates)=%d, want 2", len(preview.Candidates))
+	}
+
+	first := preview.Candidates[0]
+	if first.ContactID != "c1" {
+		t.Fatalf("first.ContactID=%q, want c1", first.ContactID)
+	}
+	if first.After.City != "千代田区" {
+		t.Fatalf("first.After.City=%q, want 千代田区", first.After.City)
+	}
+	if len(first.Diffs) != 1 || first.Diffs[0].Field != "city" {
+		t.Fatalf("first.Diffs=%v, want one city diff", first.Diffs)
+	}
+
+	second := preview.Candidates[1]
+	if second.ContactID != "c4" {
+		t.Fatalf("second.ContactID=%q, want c4", second.ContactID)
+	}
+	if len(second.Diffs) != 2 {
+		t.Fatalf("len(second.Diffs)=%d, want 2", len(second.Diffs))
+	}
+}


### PR DESCRIPTION
## 概要
- 住所正規化の一括更新フローを追加
- 変換候補プレビュー、行単位の適用/除外、差分確認、ロールバックを実装

## 変更内容
- Go 側に住所正規化の DTO / UseCase / API を追加
  - `GetAddressNormalizationPreview`
  - `ApplyAddressNormalization`
  - `RollbackAddressNormalization`
- 郵便番号辞書を用いて都道府県・市区町村の差分候補を抽出
- フロントに `AddressNormalizationDialog` を新規追加
  - 候補一覧表示
  - 行単位チェックで適用/除外
  - 変換前後差分の確認と確定
  - 直前バッチのロールバック
- 住所録画面に「住所正規化」導線を追加

## 受け入れ条件への対応
- [x] 正規化候補を一覧でプレビューできる
- [x] 行単位で適用/除外を選べる
- [x] 変換前後の差分を確認して確定できる
- [x] 誤更新に備えたロールバック手段がある

Closes #63

## テスト
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **住所正規化機能を追加**
  * 連絡先の住所を正規化する3段階のワークフロー（プレビュー、確認、結果）を実装
  * 変更内容のプレビュー確認、選択した変更の適用、適用済み変更のロールバック機能をサポート
  * 連絡先一覧に住所正規化ボタンを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->