### PR TITLE
[#64] 印刷前チェック（はみ出し・空項目・外字）を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,9 +23,31 @@ function App() {
   const { showPanel: showLabelPanel, togglePanel: toggleLabelPanel } = useLabelStore(
     useShallow((s) => ({ showPanel: s.showPanel, togglePanel: s.togglePanel })),
   )
-  const selectedCount = useContactStore((s) => s.contacts.filter((c) => c.isPrintTarget).length)
+  const {
+    selectedCount,
+    setSelectedIds,
+    setCurrentGroupId,
+    setSearchQuery,
+    setFocusContactId,
+  } = useContactStore(
+    useShallow((s) => ({
+      selectedCount: s.contacts.filter((c) => c.isPrintTarget).length,
+      setSelectedIds: s.setSelectedIds,
+      setCurrentGroupId: s.setCurrentGroupId,
+      setSearchQuery: s.setSearchQuery,
+      setFocusContactId: s.setFocusContactId,
+    })),
+  )
 
   const showPreview = view === 'contacts' || view === 'preview'
+  const handleJumpToContact = (contactID: string) => {
+    setShowPrintDialog(false)
+    setView('contacts')
+    setCurrentGroupId('')
+    setSearchQuery('')
+    setSelectedIds(new Set([contactID]))
+    setFocusContactId(contactID)
+  }
 
   return (
     <div className="flex h-screen bg-gray-50 text-gray-900">
@@ -115,7 +137,12 @@ function App() {
         {view === 'settings' && <Settings />}
       </main>
 
-      {showPrintDialog && <PrintConfirmDialog onClose={() => setShowPrintDialog(false)} />}
+      {showPrintDialog && (
+        <PrintConfirmDialog
+          onClose={() => setShowPrintDialog(false)}
+          onJumpToContact={handleJumpToContact}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/PrintConfirmDialog.tsx
+++ b/frontend/src/components/PrintConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   CheckUnsupportedCharacters,
   GenerateLabelPDF,
@@ -18,10 +18,12 @@ import { useSenderStore } from '../stores/senderStore'
 import type { ContactYearStatus } from '../types'
 import { DEFAULT_TEMPLATE, DEFAULT_TEMPLATE_HORIZONTAL } from './preview/LabelCanvas'
 import { renderLabelSnapshotsToDataURLBatch } from '../lib/labelSnapshot'
+import { buildPreprintWarnings } from '../lib/printPreflight'
 import { useShallow } from 'zustand/shallow'
 
 interface Props {
   onClose: () => void
+  onJumpToContact: (contactID: string) => void
 }
 
 /** プリセット透かし絵文字マップ (WatermarkLayer と同じ定義) */
@@ -73,12 +75,14 @@ async function renderWatermarkToDataURL(
   return canvas.toDataURL('image/png')
 }
 
-export default function PrintConfirmDialog({ onClose }: Props) {
+export default function PrintConfirmDialog({ onClose, onJumpToContact }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [unsupportedWarnings, setUnsupportedWarnings] = useState<entity.UnsupportedCharacterWarning[]>([])
   const [unsupportedCheckLoading, setUnsupportedCheckLoading] = useState(false)
   const [unsupportedCheckError, setUnsupportedCheckError] = useState<string | null>(null)
+  const [strictWarningMode, setStrictWarningMode] = useState(false)
+  const [warningAcknowledged, setWarningAcknowledged] = useState(false)
   const [selectedSenderId, setSelectedSenderId] = useState('')
   const [repeatFill, setRepeatFill] = useState(false)
   const [showBorder, setShowBorder] = useState(false)
@@ -183,17 +187,20 @@ export default function PrintConfirmDialog({ onClose }: Props) {
     : 0
   const count = printableContacts.length
   const printableContactIDs = Array.from(new Set(printableContacts.map((c) => c.id)))
-  const isPrintActionDisabled = loading || unsupportedCheckLoading || count === 0 || !annualFilterReady
   const labelsPerPage = layout.columns * layout.rows
 
   const paperLabel = `${layout.paperWidth}×${layout.paperHeight}mm (${layout.columns}列×${layout.rows}行)`
   const printableContactKey = printableContacts.map((c) => c.id).join(',')
 
-  function resolveTemplateAndContactIDs() {
+  function resolveTemplate() {
     const defaultTpl = orientation === 'horizontal' ? DEFAULT_TEMPLATE_HORIZONTAL : DEFAULT_TEMPLATE
-    const tpl = selectedTemplate
+    return selectedTemplate
       ? { ...selectedTemplate, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
       : { ...defaultTpl, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
+  }
+
+  function resolveTemplateAndContactIDs() {
+    const tpl = resolveTemplate()
 
     let ids = printableContacts.map((c) => c.id)
     if (repeatFill && ids.length > 0 && ids.length < labelsPerPage) {
@@ -208,6 +215,25 @@ export default function PrintConfirmDialog({ onClose }: Props) {
     return { tpl, ids }
   }
 
+  const resolvedTemplate = useMemo(resolveTemplate, [orientation, selectedTemplate, layout])
+  const preprintWarnings = useMemo(
+    () => buildPreprintWarnings(printableContacts, resolvedTemplate, unsupportedWarnings),
+    [printableContacts, resolvedTemplate, unsupportedWarnings],
+  )
+  const warningSignature = preprintWarnings.map((warning) => warning.id).join('|')
+
+  useEffect(() => {
+    setWarningAcknowledged(false)
+  }, [warningSignature, strictWarningMode])
+
+  const requiresWarningConfirmation = strictWarningMode && preprintWarnings.length > 0
+  const isPrintActionDisabled =
+    loading ||
+    unsupportedCheckLoading ||
+    count === 0 ||
+    !annualFilterReady ||
+    (requiresWarningConfirmation && !warningAcknowledged)
+
   useEffect(() => {
     if (!annualFilterReady || count === 0) {
       setUnsupportedWarnings([])
@@ -216,10 +242,7 @@ export default function PrintConfirmDialog({ onClose }: Props) {
       return
     }
 
-    const defaultTpl = orientation === 'horizontal' ? DEFAULT_TEMPLATE_HORIZONTAL : DEFAULT_TEMPLATE
-    const tpl = selectedTemplate
-      ? { ...selectedTemplate, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
-      : { ...defaultTpl, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
+    const tpl = resolvedTemplate
     let ids = printableContacts.map((c) => c.id)
     if (repeatFill && ids.length > 0 && ids.length < labelsPerPage) {
       const filled: string[] = []
@@ -265,9 +288,7 @@ export default function PrintConfirmDialog({ onClose }: Props) {
     printableContactKey,
     repeatFill,
     labelsPerPage,
-    orientation,
-    selectedTemplate,
-    layout,
+    resolvedTemplate,
     selectedSenderId,
     showBorder,
   ])
@@ -472,16 +493,51 @@ export default function PrintConfirmDialog({ onClose }: Props) {
               未対応文字チェックに失敗しました。印刷時に文字化けがないか確認してください。
             </p>
           )}
-          {unsupportedWarnings.length > 0 && (
-            <div className="text-xs text-amber-900 bg-amber-50 rounded px-2 py-2 space-y-1">
-              <p className="font-medium">未対応文字の可能性があります（印刷前確認）</p>
-              {unsupportedWarnings.slice(0, 5).map((warning) => (
-                <p key={`${warning.contactId}-${warning.characters.join('')}`}>
-                  {warning.contactName || warning.contactId}: {warning.characters.join(' ')}
-                </p>
+          <label className="flex items-center gap-2 cursor-pointer select-none pt-1">
+            <input
+              type="checkbox"
+              checked={strictWarningMode}
+              onChange={(e) => setStrictWarningMode(e.target.checked)}
+              className="w-3.5 h-3.5 accent-amber-600"
+            />
+            <span className="text-gray-600">警告確認を必須にする（未確認時は印刷不可）</span>
+          </label>
+          {preprintWarnings.length > 0 && (
+            <div className="text-xs text-amber-900 bg-amber-50 rounded px-2 py-2 space-y-2">
+              <p className="font-medium">印刷前チェックで {preprintWarnings.length} 件の警告があります</p>
+              {preprintWarnings.slice(0, 8).map((warning) => (
+                <div key={warning.id} className="flex items-start justify-between gap-2">
+                  <p className="leading-5">
+                    <span className="font-medium">
+                      {warning.kind === 'required' && '必須不足'}
+                      {warning.kind === 'overflow' && 'はみ出し'}
+                      {warning.kind === 'unsupported' && '未対応文字'}
+                    </span>
+                    {' '}
+                    {warning.contactName}: {warning.message}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => onJumpToContact(warning.contactId)}
+                    className="shrink-0 rounded border border-amber-300 bg-white px-2 py-0.5 text-[11px] text-amber-800 hover:bg-amber-100"
+                  >
+                    該当へ移動
+                  </button>
+                </div>
               ))}
-              {unsupportedWarnings.length > 5 && (
-                <p>ほか {unsupportedWarnings.length - 5} 件</p>
+              {preprintWarnings.length > 8 && (
+                <p>ほか {preprintWarnings.length - 8} 件</p>
+              )}
+              {requiresWarningConfirmation && (
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={warningAcknowledged}
+                    onChange={(e) => setWarningAcknowledged(e.target.checked)}
+                    className="w-3.5 h-3.5 accent-amber-700"
+                  />
+                  <span>警告内容を確認しました</span>
+                </label>
               )}
             </div>
           )}

--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -53,6 +53,7 @@ export default function ContactList() {
   const {
     contacts,
     selectedIds,
+    focusContactId,
     currentGroupId,
     searchQuery,
     annualStatusYear,
@@ -61,6 +62,7 @@ export default function ContactList() {
     annualStatusesLoading,
     setContacts,
     setSelectedIds,
+    clearFocusContactId,
     toggleSelected,
     clearSelection,
     setCurrentGroupId,
@@ -88,10 +90,12 @@ export default function ContactList() {
   const [updatingAnnualStatusKeys, setUpdatingAnnualStatusKeys] = useState<Set<string>>(new Set())
 
   const requestIdRef = useRef(0)
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map())
   const editingCellRef = useRef<EditingCell | null>(null)
   const committingRef = useRef(false)
   const skipBlurRef = useRef(false)
   const skipBlurResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [focusedRowId, setFocusedRowID] = useState<string | null>(null)
 
   const getCellKey = (contactId: string, field: EditableField) => `${contactId}:${field}`
 
@@ -193,6 +197,47 @@ export default function ContactList() {
       setEditingCell(null)
     }
   }, [displayContacts, editingCell])
+
+  useEffect(() => {
+    if (!focusContactId) return
+    if (showPrintTargetOnly) {
+      setShowPrintTargetOnly(false)
+      return
+    }
+    if (searchQuery) {
+      setSearchQuery('')
+      return
+    }
+    if (currentGroupId) {
+      setCurrentGroupId('')
+      return
+    }
+    if (loading) return
+    if (!displayContacts.some((contact) => contact.id === focusContactId)) return
+
+    setSelectedIds(new Set([focusContactId]))
+    setFocusedRowID(focusContactId)
+    clearFocusContactId()
+
+    const row = rowRefs.current.get(focusContactId)
+    row?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+
+    const timer = setTimeout(() => {
+      setFocusedRowID((current) => (current === focusContactId ? null : current))
+    }, 2500)
+    return () => clearTimeout(timer)
+  }, [
+    focusContactId,
+    showPrintTargetOnly,
+    searchQuery,
+    currentGroupId,
+    loading,
+    displayContacts,
+    setSelectedIds,
+    clearFocusContactId,
+    setSearchQuery,
+    setCurrentGroupId,
+  ])
 
   const refreshContacts = async () => {
     const result = searchQuery
@@ -788,7 +833,20 @@ export default function ContactList() {
                 return (
                   <tr
                     key={c.id}
-                    className={`hover:bg-gray-50 ${selectedIds.has(c.id) ? 'bg-blue-50/70' : ''}`}
+                    ref={(el) => {
+                      if (el) {
+                        rowRefs.current.set(c.id, el)
+                      } else {
+                        rowRefs.current.delete(c.id)
+                      }
+                    }}
+                    className={`hover:bg-gray-50 ${
+                      focusedRowId === c.id
+                        ? 'bg-amber-100'
+                        : selectedIds.has(c.id)
+                          ? 'bg-blue-50/70'
+                          : ''
+                    }`}
                     onDoubleClick={() => setEditTarget(c)}
                   >
                     <td className="px-2 py-1.5 border-b border-gray-100 align-top">

--- a/frontend/src/lib/labelRenderer.ts
+++ b/frontend/src/lib/labelRenderer.ts
@@ -269,7 +269,7 @@ function computeVerticalNameLayout(contact: Contact, tpl: Template): VerticalNam
     tpl.labelHeight - rc.nameY - NAME_AUTO_LAYOUT_RULES.verticalBottomPaddingMm,
   )
 
-  let leftLimitMm = NAME_AUTO_LAYOUT_RULES.verticalLeftPaddingMm
+  let leftLimitMm: number = NAME_AUTO_LAYOUT_RULES.verticalLeftPaddingMm
   if (rc.addressX > 0 && rc.addressX < rc.nameX) {
     leftLimitMm = Math.max(
       leftLimitMm,

--- a/frontend/src/lib/printPreflight.test.ts
+++ b/frontend/src/lib/printPreflight.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type { Contact, Template } from '../types'
+import { buildPreprintWarnings } from './printPreflight'
+
+const baseContact: Contact = {
+  id: 'c1',
+  familyName: '山田',
+  givenName: '太郎',
+  familyNameKana: '',
+  givenNameKana: '',
+  isPrintTarget: true,
+  honorific: '様',
+  postalCode: '1000001',
+  prefecture: '東京都',
+  city: '千代田区',
+  street: '1-2-3',
+  building: 'テストビル',
+  company: '',
+  department: '',
+  notes: '',
+  createdAt: '',
+  updatedAt: '',
+}
+
+const baseTemplate: Template = {
+  id: 'tmpl',
+  name: 'test',
+  orientation: 'horizontal',
+  labelWidth: 86.4,
+  labelHeight: 42.3,
+  recipient: {
+    nameX: 8,
+    nameY: 8,
+    nameFont: 13,
+    addressX: 8,
+    addressY: 20,
+    addressFont: 8.5,
+  },
+  sender: {
+    nameX: 16,
+    nameY: 24,
+    nameFont: 6.5,
+    addressX: 8,
+    addressY: 24,
+    addressFont: 5.5,
+  },
+}
+
+describe('buildPreprintWarnings', () => {
+  it('必須項目不足を検知する', () => {
+    const warnings = buildPreprintWarnings(
+      [{ ...baseContact, familyName: '', postalCode: '' }],
+      baseTemplate,
+      [],
+    )
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].kind).toBe('required')
+    expect(warnings[0].message).toContain('姓')
+    expect(warnings[0].message).toContain('郵便番号')
+  })
+
+  it('未対応文字警告を取り込む', () => {
+    const warnings = buildPreprintWarnings(
+      [baseContact],
+      baseTemplate,
+      [{ contactId: 'c1', contactName: '山田太郎', characters: ['髙'] }],
+    )
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].kind).toBe('unsupported')
+    expect(warnings[0].message).toContain('髙')
+  })
+
+  it('狭いラベルで文字はみ出し疑いを検知する', () => {
+    const warnings = buildPreprintWarnings(
+      [
+        {
+          ...baseContact,
+          familyName: '山田太郎次郎三郎四郎五郎六郎七郎八郎九郎十郎',
+          givenName: '',
+          street: '千代田区千代田1-1-1皇居外苑超長い住所テキスト',
+        },
+      ],
+      {
+        ...baseTemplate,
+        labelWidth: 24,
+        labelHeight: 24,
+        recipient: {
+          ...baseTemplate.recipient,
+          nameX: 5,
+          nameY: 4,
+          addressX: 5,
+          addressY: 13,
+        },
+      },
+      [],
+    )
+
+    expect(warnings.some((warning) => warning.kind === 'overflow')).toBe(true)
+  })
+})

--- a/frontend/src/lib/printPreflight.ts
+++ b/frontend/src/lib/printPreflight.ts
@@ -1,0 +1,397 @@
+import type { Contact, Template } from '../types'
+
+export type PreprintWarningKind = 'required' | 'overflow' | 'unsupported'
+
+export interface PreprintWarning {
+  id: string
+  kind: PreprintWarningKind
+  contactId: string
+  contactName: string
+  message: string
+}
+
+interface UnsupportedCharacterWarningLike {
+  contactId: string
+  contactName: string
+  characters: string[]
+}
+
+const JOINT_NAME_SEPARATOR = /[・･/／&＆]/
+const PT_TO_MM = 25.4 / 72
+const EPSILON = 1e-6
+
+const RULES = {
+  horizontalMinFontPt: 7,
+  horizontalSplitThresholdChars: 12,
+  horizontalLineHeight: 1.35,
+  horizontalRightPaddingMm: 2,
+  horizontalBottomPaddingMm: 2,
+  horizontalAddressGapMm: 1.2,
+  horizontalGlyphWidthRatio: 0.95,
+  verticalMinFontPt: 6,
+  verticalBottomPaddingMm: 2,
+  verticalLeftPaddingMm: 2,
+  verticalAddressGapMm: 1.2,
+  verticalColumnGapRatio: 0.2,
+  verticalCharHeightRatio: 1.05,
+  maxVerticalColumns: 3,
+} as const
+
+function ptToMm(valuePt: number): number {
+  return valuePt * PT_TO_MM
+}
+
+function contactName(contact: Contact): string {
+  const fullName = `${contact.familyName}${contact.givenName}`.trim()
+  return fullName || contact.id
+}
+
+function estimateTextUnits(text: string): number {
+  let units = 0
+  for (const ch of [...text]) {
+    if (ch === ' ' || ch === '\u3000') {
+      units += 0.55
+    } else if (/^[\u0020-\u007E\uFF61-\uFF9F]$/.test(ch)) {
+      units += 0.55
+    } else if (ch === 'ー' || ch === 'ｰ' || ch === '-') {
+      units += 0.8
+    } else {
+      units += 1
+    }
+  }
+  return units
+}
+
+function estimateLineWidthMm(text: string, fontPt: number): number {
+  return estimateTextUnits(text) * ptToMm(fontPt) * RULES.horizontalGlyphWidthRatio
+}
+
+function listFontCandidates(basePt: number, minPt: number): number[] {
+  const floor = Math.min(basePt, minPt)
+  if (basePt <= floor + EPSILON) return [basePt]
+
+  const out: number[] = []
+  for (let pt = basePt; pt >= floor - EPSILON; pt -= 0.5) {
+    out.push(Math.round(pt * 10) / 10)
+  }
+  if (Math.abs(out[out.length - 1] - floor) > EPSILON) {
+    out.push(floor)
+  }
+  return [...new Set(out)]
+}
+
+function splitEvenly(text: string, pieces: number): string[] {
+  const chars = [...text]
+  if (pieces <= 1 || chars.length <= 1) return [text]
+
+  const bucketCount = Math.min(pieces, chars.length)
+  const out: string[] = []
+  let index = 0
+  for (let i = 0; i < bucketCount; i++) {
+    const remainingChars = chars.length - index
+    const remainingBuckets = bucketCount - i
+    const take = Math.ceil(remainingChars / remainingBuckets)
+    out.push(chars.slice(index, index + take).join(''))
+    index += take
+  }
+  return out.filter(Boolean)
+}
+
+function splitJointNameBody(nameBody: string): string[] {
+  const out: string[] = []
+  let buf = ''
+  for (const ch of [...nameBody]) {
+    if (JOINT_NAME_SEPARATOR.test(ch)) {
+      if (buf) {
+        out.push(`${buf}${ch}`)
+        buf = ''
+      }
+      continue
+    }
+    buf += ch
+  }
+  if (buf) out.push(buf)
+  return out.length >= 2 ? out : []
+}
+
+function buildHorizontalNameCandidates(contact: Contact, honorific: string): string[][] {
+  const nameBody = `${contact.familyName}${contact.givenName}`
+  const defaultNameLine = `${nameBody}\u3000${honorific}`
+  const company = contact.company.trim()
+  const department = contact.department.trim()
+  const orgLines = [company, department].filter(Boolean)
+
+  let splitNameLines: string[] = [defaultNameLine]
+  const jointParts = splitJointNameBody(nameBody)
+  if (jointParts.length >= 2) {
+    splitNameLines = [...jointParts]
+    splitNameLines[splitNameLines.length - 1] = `${splitNameLines[splitNameLines.length - 1]}\u3000${honorific}`
+  } else if ([...nameBody].length >= RULES.horizontalSplitThresholdChars) {
+    const [first, second] = splitEvenly(nameBody, 2)
+    if (first && second) {
+      splitNameLines = [first, `${second}\u3000${honorific}`]
+    }
+  }
+
+  const mergedOrgLines = orgLines.length > 1 ? [orgLines.join(' ')] : orgLines
+  const keys = new Set<string>()
+  const candidates: string[][] = []
+  const add = (lines: string[]) => {
+    const normalized = lines.filter(Boolean)
+    if (normalized.length === 0) return
+    const key = normalized.join('\n')
+    if (keys.has(key)) return
+    keys.add(key)
+    candidates.push(normalized)
+  }
+
+  add([...orgLines, defaultNameLine])
+  add([...orgLines, ...splitNameLines])
+  add([...mergedOrgLines, defaultNameLine])
+  add([...mergedOrgLines, ...splitNameLines])
+  add([defaultNameLine])
+  add(splitNameLines)
+
+  return candidates
+}
+
+function hasHorizontalNameOverflow(contact: Contact, template: Template): boolean {
+  const recipient = template.recipient
+  const honorific = contact.honorific || '様'
+  const candidates = buildHorizontalNameCandidates(contact, honorific)
+  const baseFontPt = recipient.nameFont
+  const minFontPt = Math.min(baseFontPt, RULES.horizontalMinFontPt)
+
+  const availableWidthMm = Math.max(10, template.labelWidth - recipient.nameX - RULES.horizontalRightPaddingMm)
+  let availableHeightMm = template.labelHeight - recipient.nameY - RULES.horizontalBottomPaddingMm
+  if (recipient.addressY > recipient.nameY) {
+    availableHeightMm = Math.min(
+      availableHeightMm,
+      recipient.addressY - recipient.nameY - RULES.horizontalAddressGapMm,
+    )
+  }
+  availableHeightMm = Math.max(availableHeightMm, ptToMm(minFontPt) * RULES.horizontalLineHeight)
+
+  const fontCandidates = listFontCandidates(baseFontPt, minFontPt)
+  for (const lines of candidates) {
+    for (const fontPt of fontCandidates) {
+      const lineHeightMm = ptToMm(fontPt) * RULES.horizontalLineHeight
+      const requiredHeightMm = lineHeightMm * lines.length
+      if (requiredHeightMm > availableHeightMm + EPSILON) continue
+
+      const maxLineWidthMm = lines.reduce((max, line) => Math.max(max, estimateLineWidthMm(line, fontPt)), 0)
+      if (maxLineWidthMm <= availableWidthMm + EPSILON) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+function buildVerticalNameCandidates(nameBody: string, honorific: string): string[][] {
+  const fullName = `${nameBody}${honorific}`
+  const keys = new Set<string>()
+  const candidates: string[][] = []
+  const add = (columns: string[]) => {
+    const normalized = columns.filter(Boolean)
+    if (normalized.length === 0) return
+    const key = normalized.join('\n')
+    if (keys.has(key)) return
+    keys.add(key)
+    candidates.push(normalized)
+  }
+
+  add([fullName])
+
+  const jointParts = splitJointNameBody(nameBody)
+  if (jointParts.length >= 2) {
+    const columns = [...jointParts].slice(0, RULES.maxVerticalColumns)
+    if (jointParts.length > RULES.maxVerticalColumns) {
+      columns[columns.length - 1] += jointParts.slice(RULES.maxVerticalColumns).join('')
+    }
+    columns[columns.length - 1] = `${columns[columns.length - 1]}${honorific}`
+    add(columns)
+  }
+
+  for (let cols = 2; cols <= RULES.maxVerticalColumns; cols++) {
+    const columns = splitEvenly(nameBody, cols)
+    if (columns.length <= 1) continue
+    columns[columns.length - 1] = `${columns[columns.length - 1]}${honorific}`
+    add(columns)
+  }
+  return candidates
+}
+
+function hasVerticalNameOverflow(contact: Contact, template: Template): boolean {
+  const recipient = template.recipient
+  const honorific = contact.honorific || '様'
+  const nameBody = `${contact.familyName}${contact.givenName}`
+  const candidates = buildVerticalNameCandidates(nameBody, honorific)
+  const baseFontPt = recipient.nameFont
+  const minFontPt = Math.min(baseFontPt, RULES.verticalMinFontPt)
+  const fontCandidates = listFontCandidates(baseFontPt, minFontPt)
+
+  const availableHeightMm = Math.max(
+    ptToMm(minFontPt) * RULES.verticalCharHeightRatio,
+    template.labelHeight - recipient.nameY - RULES.verticalBottomPaddingMm,
+  )
+  let leftLimitMm: number = RULES.verticalLeftPaddingMm
+  if (recipient.addressX > 0 && recipient.addressX < recipient.nameX) {
+    leftLimitMm = Math.max(
+      leftLimitMm,
+      recipient.addressX + ptToMm(recipient.addressFont) * 1.2 + RULES.verticalAddressGapMm,
+    )
+  }
+  const availableWidthMm = Math.max(ptToMm(minFontPt), recipient.nameX - leftLimitMm)
+
+  for (const columns of candidates) {
+    const maxChars = columns.reduce((max, value) => Math.max(max, [...value].length), 0)
+    if (maxChars <= 0) continue
+
+    for (const fontPt of fontCandidates) {
+      const fontMm = ptToMm(fontPt)
+      const colGap = fontMm * RULES.verticalColumnGapRatio
+      const requiredWidthMm = fontMm * columns.length + colGap * (columns.length - 1)
+      const requiredHeightMm = maxChars * fontMm * RULES.verticalCharHeightRatio
+      if (requiredWidthMm <= availableWidthMm + EPSILON && requiredHeightMm <= availableHeightMm + EPSILON) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+function hasHorizontalAddressOverflow(contact: Contact, template: Template): boolean {
+  const recipient = template.recipient
+  const lines = [
+    `${contact.prefecture}${contact.city}`,
+    `${contact.street}${contact.building ? `　${contact.building}` : ''}`,
+  ].filter(Boolean)
+  if (lines.length === 0) return false
+
+  const fontMm = ptToMm(recipient.addressFont)
+  const lineHeightMm = fontMm * 1.5
+  const availableWidthMm = Math.max(8, template.labelWidth - recipient.addressX - 2)
+  const availableHeightMm = Math.max(lineHeightMm, template.labelHeight - recipient.addressY - 2)
+  const requiredHeightMm = lineHeightMm * lines.length
+  if (requiredHeightMm > availableHeightMm + EPSILON) return true
+
+  return lines.some((line) => estimateLineWidthMm(line, recipient.addressFont) > availableWidthMm + EPSILON)
+}
+
+function hasVerticalAddressOverflow(contact: Contact, template: Template): boolean {
+  const recipient = template.recipient
+  const lines = [
+    `${contact.prefecture}${contact.city}`,
+    `${contact.street}${contact.building ? `　${contact.building}` : ''}`,
+  ].filter(Boolean)
+  if (lines.length === 0) return false
+
+  const fontMm = ptToMm(recipient.addressFont)
+  const colGap = fontMm * RULES.verticalColumnGapRatio
+  const requiredWidthMm = fontMm * lines.length + colGap * (lines.length - 1)
+  const availableWidthMm = Math.max(fontMm, recipient.addressX - RULES.verticalLeftPaddingMm)
+  if (requiredWidthMm > availableWidthMm + EPSILON) return true
+
+  const maxChars = lines.reduce((max, line) => Math.max(max, [...line].length), 0)
+  const requiredHeightMm = maxChars * fontMm * RULES.verticalCharHeightRatio
+  const availableHeightMm = Math.max(
+    fontMm * RULES.verticalCharHeightRatio,
+    template.labelHeight - recipient.addressY - RULES.verticalBottomPaddingMm,
+  )
+  return requiredHeightMm > availableHeightMm + EPSILON
+}
+
+function hasOverflowRisk(contact: Contact, template: Template): boolean {
+  if (template.orientation === 'horizontal') {
+    return hasHorizontalNameOverflow(contact, template) || hasHorizontalAddressOverflow(contact, template)
+  }
+  return hasVerticalNameOverflow(contact, template) || hasVerticalAddressOverflow(contact, template)
+}
+
+function buildRequiredFieldWarning(contact: Contact): PreprintWarning | null {
+  const missingFields: string[] = []
+  if (!contact.familyName.trim()) missingFields.push('姓')
+  if (!contact.givenName.trim()) missingFields.push('名')
+  if (!contact.prefecture.trim()) missingFields.push('都道府県')
+  if (!contact.city.trim()) missingFields.push('市区町村')
+  if (!contact.street.trim()) missingFields.push('番地')
+  if (!contact.postalCode.replace(/\D/g, '')) missingFields.push('郵便番号')
+
+  if (missingFields.length === 0) return null
+  return {
+    id: `required:${contact.id}`,
+    kind: 'required',
+    contactId: contact.id,
+    contactName: contactName(contact),
+    message: `必須項目不足: ${missingFields.join(' / ')}`,
+  }
+}
+
+function buildOverflowWarning(contact: Contact, template: Template): PreprintWarning | null {
+  if (!hasOverflowRisk(contact, template)) return null
+  return {
+    id: `overflow:${contact.id}`,
+    kind: 'overflow',
+    contactId: contact.id,
+    contactName: contactName(contact),
+    message: '文字がはみ出す可能性があります',
+  }
+}
+
+function buildUnsupportedWarnings(
+  unsupportedWarnings: UnsupportedCharacterWarningLike[],
+  contactByID: Map<string, Contact>,
+): PreprintWarning[] {
+  return unsupportedWarnings.map((warning) => {
+    const matchedContact = contactByID.get(warning.contactId)
+    const name = warning.contactName || (matchedContact ? contactName(matchedContact) : warning.contactId)
+    return {
+      id: `unsupported:${warning.contactId}:${warning.characters.join('')}`,
+      kind: 'unsupported',
+      contactId: warning.contactId,
+      contactName: name,
+      message: `未対応文字: ${warning.characters.join(' ')}`,
+    }
+  })
+}
+
+export function buildPreprintWarnings(
+  contacts: Contact[],
+  template: Template,
+  unsupportedWarnings: UnsupportedCharacterWarningLike[],
+): PreprintWarning[] {
+  const warnings: PreprintWarning[] = []
+  const contactByID = new Map(contacts.map((contact) => [contact.id, contact]))
+
+  for (const contact of contacts) {
+    const requiredWarning = buildRequiredFieldWarning(contact)
+    if (requiredWarning) {
+      warnings.push(requiredWarning)
+    }
+    const overflowWarning = buildOverflowWarning(contact, template)
+    if (overflowWarning) {
+      warnings.push(overflowWarning)
+    }
+  }
+
+  warnings.push(...buildUnsupportedWarnings(unsupportedWarnings, contactByID))
+
+  const priority: Record<PreprintWarningKind, number> = {
+    required: 0,
+    overflow: 1,
+    unsupported: 2,
+  }
+  warnings.sort((a, b) => {
+    if (priority[a.kind] !== priority[b.kind]) {
+      return priority[a.kind] - priority[b.kind]
+    }
+    if (a.contactName !== b.contactName) {
+      return a.contactName.localeCompare(b.contactName, 'ja')
+    }
+    return a.message.localeCompare(b.message, 'ja')
+  })
+
+  return warnings
+}

--- a/frontend/src/stores/contactStore.ts
+++ b/frontend/src/stores/contactStore.ts
@@ -4,6 +4,7 @@ import type { Contact, ContactYearStatus } from '../types'
 interface ContactState {
   contacts: Contact[]
   selectedIds: Set<string>
+  focusContactId: string | null
   currentGroupId: string
   searchQuery: string
   annualStatusYear: number
@@ -12,6 +13,8 @@ interface ContactState {
   annualStatusesLoading: boolean
   setContacts: (contacts: Contact[]) => void
   setSelectedIds: (ids: Set<string>) => void
+  setFocusContactId: (id: string | null) => void
+  clearFocusContactId: () => void
   toggleSelected: (id: string) => void
   selectAll: () => void
   clearSelection: () => void
@@ -26,6 +29,7 @@ interface ContactState {
 export const useContactStore = create<ContactState>((set, get) => ({
   contacts: [],
   selectedIds: new Set(),
+  focusContactId: null,
   currentGroupId: '',
   searchQuery: '',
   annualStatusYear: new Date().getFullYear(),
@@ -35,6 +39,8 @@ export const useContactStore = create<ContactState>((set, get) => ({
 
   setContacts: (contacts) => set({ contacts }),
   setSelectedIds: (ids) => set({ selectedIds: ids }),
+  setFocusContactId: (id) => set({ focusContactId: id }),
+  clearFocusContactId: () => set({ focusContactId: null }),
 
   toggleSelected: (id) => {
     const ids = new Set(get().selectedIds)


### PR DESCRIPTION
## 概要
- 印刷前チェックに「必須項目不足」「はみ出し疑い」「未対応文字」を追加
- 警告一覧から該当連絡先へ移動できる導線を追加
- 警告を確認しないと印刷できない確認必須モードを追加

## 実装詳細
- `frontend/src/lib/printPreflight.ts` を追加し、印刷前チェックロジックを集約
- `PrintConfirmDialog` で警告の統合表示・確認必須モード・該当連絡先移動を実装
- `App` / `contactStore` / `ContactList` で遷移先連絡先のフォーカス表示を実装
- 既存の型推論エラー回避のため `labelRenderer.ts` の `leftLimitMm` に型注釈を追加

## テスト
- `npm --prefix frontend run test:run`
- `npm --prefix frontend run build`
- `go test ./...`

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 印刷前に必須項目の未入力、文字数オーバーフロー、未対応文字を検出する警告システムを追加。警告がある場合は確認チェックボックスで承認するまで印刷を禁止します。
  * 印刷ダイアログから問題のある連絡先へ直接移動できる機能を追加。
  * 連絡先リストでフォーカスされた行をハイライト表示します。

* **テスト**
  * 印刷前検証のテストスイートを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->