### PR TITLE
feat: 自動バックアップ・復元（世代管理）を実装

### DIFF
--- a/app.go
+++ b/app.go
@@ -3,13 +3,11 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"sync"
 	"time"
 
@@ -22,23 +20,6 @@ import (
 
 // AppVersion はアプリのバージョン文字列。
 const AppVersion = "1.0.0"
-
-const (
-	defaultBackupIntervalMinutes = 0
-	defaultBackupMaxGenerations  = 20
-)
-
-type backupIndex struct {
-	Generations []backupIndexEntry `json:"generations"`
-}
-
-type backupIndexEntry struct {
-	ID           string    `json:"id"`
-	CreatedAt    time.Time `json:"createdAt"`
-	ContactCount int       `json:"contactCount"`
-	Trigger      string    `json:"trigger"`
-	FileName     string    `json:"fileName"`
-}
 
 // App struct
 type App struct {
@@ -54,17 +35,11 @@ type App struct {
 	senderUseCase       *usecase.SenderUseCase
 	postalRepo          repository.PostalRepository
 	printHistoryUseCase *usecase.PrintHistoryUseCase
+	backupUseCase       *usecase.BackupUseCase
 	db                  *sql.DB
 	dbPath              string
 	normMu              sync.Mutex
 	lastNormBatch       *addressNormalizationRollbackBatch
-	backupMu            sync.Mutex
-	backupSettings      entity.BackupSettings
-	backupSettingsPath  string
-	backupIndexPath     string
-	backupDir           string
-	backupTickerStop    chan struct{}
-	backupTickerDone    chan struct{}
 }
 
 type addressNormalizationRollbackBatch struct {
@@ -73,8 +48,7 @@ type addressNormalizationRollbackBatch struct {
 }
 
 // NewApp creates a new App application struct
-func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.ContactYearStatusUseCase, csvUC *usecase.CSVUseCase, groupUC *usecase.GroupUseCase, watermarkUC *usecase.WatermarkUseCase, qrCodeUC *usecase.QRCodeUseCase, printUC *usecase.PrintUseCase, senderUC *usecase.SenderUseCase, postalRepo repository.PostalRepository, printHistoryUC *usecase.PrintHistoryUseCase, db *sql.DB, dbPath string) *App {
-	dataDir := filepath.Dir(dbPath)
+func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.ContactYearStatusUseCase, csvUC *usecase.CSVUseCase, groupUC *usecase.GroupUseCase, watermarkUC *usecase.WatermarkUseCase, qrCodeUC *usecase.QRCodeUseCase, printUC *usecase.PrintUseCase, senderUC *usecase.SenderUseCase, postalRepo repository.PostalRepository, printHistoryUC *usecase.PrintHistoryUseCase, backupUC *usecase.BackupUseCase, db *sql.DB, dbPath string) *App {
 	return &App{
 		contactUseCase:      contactUC,
 		contactYearStatusUC: contactYearStatusUC,
@@ -87,12 +61,9 @@ func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.Cont
 		senderUseCase:       senderUC,
 		postalRepo:          postalRepo,
 		printHistoryUseCase: printHistoryUC,
+		backupUseCase:       backupUC,
 		db:                  db,
 		dbPath:              dbPath,
-		backupSettings:      defaultBackupSettings(),
-		backupSettingsPath:  filepath.Join(dataDir, "backup_settings.json"),
-		backupIndexPath:     filepath.Join(dataDir, "backup_index.json"),
-		backupDir:           filepath.Join(dataDir, "backups"),
 	}
 }
 
@@ -100,22 +71,9 @@ func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.Cont
 // so we can call the runtime methods
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
-
-	if err := a.loadBackupSettings(); err != nil {
-		log.Printf("backup settings load failed: %v", err)
-	}
-	if err := a.reconfigureBackupTicker(); err != nil {
-		log.Printf("backup scheduler start failed: %v", err)
-	}
-
-	settings, err := a.GetBackupSettings()
-	if err != nil {
-		log.Printf("backup settings read failed: %v", err)
-		return
-	}
-	if settings.Timing.OnStartup {
-		if _, err := a.runManagedBackup("startup"); err != nil {
-			log.Printf("startup backup failed: %v", err)
+	if a.backupUseCase != nil {
+		if err := a.backupUseCase.Startup(ctx); err != nil {
+			log.Printf("backup startup failed: %v", err)
 		}
 	}
 }
@@ -123,16 +81,9 @@ func (a *App) startup(ctx context.Context) {
 // shutdown is called right before the app terminates.
 func (a *App) shutdown(ctx context.Context) {
 	_ = ctx
-	a.stopBackupTicker()
-
-	settings, err := a.GetBackupSettings()
-	if err != nil {
-		log.Printf("backup settings read failed: %v", err)
-		return
-	}
-	if settings.Timing.OnShutdown {
-		if _, err := a.runManagedBackup("shutdown"); err != nil {
-			log.Printf("shutdown backup failed: %v", err)
+	if a.backupUseCase != nil {
+		if err := a.backupUseCase.Shutdown(a.ctx); err != nil {
+			log.Printf("backup shutdown failed: %v", err)
 		}
 	}
 }
@@ -700,351 +651,51 @@ func (a *App) ImportDB() (bool, error) {
 
 // GetBackupSettings returns current automatic backup settings.
 func (a *App) GetBackupSettings() (entity.BackupSettings, error) {
-	a.backupMu.Lock()
-	defer a.backupMu.Unlock()
-	return normalizeBackupSettings(a.backupSettings), nil
+	if a.backupUseCase == nil {
+		return entity.BackupSettings{}, fmt.Errorf("GetBackupSettings: backup usecase is not initialized")
+	}
+	settings, err := a.backupUseCase.GetSettings()
+	if err != nil {
+		return entity.BackupSettings{}, fmt.Errorf("GetBackupSettings: %w", err)
+	}
+	return settings, nil
 }
 
 // SaveBackupSettings updates automatic backup settings and restarts scheduler.
 func (a *App) SaveBackupSettings(settings entity.BackupSettings) (entity.BackupSettings, error) {
-	normalized := normalizeBackupSettings(settings)
-
-	a.backupMu.Lock()
-	a.backupSettings = normalized
-	if err := a.persistBackupSettingsLocked(); err != nil {
-		a.backupMu.Unlock()
+	if a.backupUseCase == nil {
+		return entity.BackupSettings{}, fmt.Errorf("SaveBackupSettings: backup usecase is not initialized")
+	}
+	saved, err := a.backupUseCase.SaveSettings(settings)
+	if err != nil {
 		return entity.BackupSettings{}, fmt.Errorf("SaveBackupSettings: %w", err)
 	}
-	a.backupMu.Unlock()
-
-	if err := a.reconfigureBackupTicker(); err != nil {
-		return entity.BackupSettings{}, fmt.Errorf("SaveBackupSettings scheduler: %w", err)
-	}
-	return normalized, nil
+	return saved, nil
 }
 
 // ListBackupGenerations returns restorable backup generations.
 func (a *App) ListBackupGenerations() ([]entity.BackupGeneration, error) {
-	a.backupMu.Lock()
-	index, err := a.loadBackupIndexLocked()
+	if a.backupUseCase == nil {
+		return nil, fmt.Errorf("ListBackupGenerations: backup usecase is not initialized")
+	}
+	list, err := a.backupUseCase.ListGenerations()
 	if err != nil {
-		a.backupMu.Unlock()
 		return nil, fmt.Errorf("ListBackupGenerations: %w", err)
 	}
-	filtered := make([]backupIndexEntry, 0, len(index.Generations))
-	changed := false
-	for _, entry := range index.Generations {
-		if entry.FileName == "" {
-			changed = true
-			continue
-		}
-		fullPath := filepath.Join(a.backupDir, entry.FileName)
-		if _, statErr := os.Stat(fullPath); statErr != nil {
-			if os.IsNotExist(statErr) {
-				changed = true
-				continue
-			}
-			a.backupMu.Unlock()
-			return nil, fmt.Errorf("ListBackupGenerations stat %s: %w", entry.FileName, statErr)
-		}
-		filtered = append(filtered, entry)
-	}
-	if changed {
-		index.Generations = filtered
-		if err := a.saveBackupIndexLocked(index); err != nil {
-			a.backupMu.Unlock()
-			return nil, fmt.Errorf("ListBackupGenerations cleanup index: %w", err)
-		}
-	}
-
-	list := make([]entity.BackupGeneration, 0, len(index.Generations))
-	for _, entry := range index.Generations {
-		list = append(list, entity.BackupGeneration{
-			ID:           entry.ID,
-			CreatedAt:    entry.CreatedAt,
-			ContactCount: entry.ContactCount,
-			Trigger:      entry.Trigger,
-		})
-	}
-	a.backupMu.Unlock()
-
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].CreatedAt.After(list[j].CreatedAt)
-	})
 	return list, nil
 }
 
-// RestoreBackupGeneration restores one backup generation.
-// The restored data is reflected after app restart.
+// RestoreBackupGeneration schedules restore for one backup generation.
+// The actual file replacement is applied on next app startup.
 func (a *App) RestoreBackupGeneration(backupID string) (entity.RestoreBackupResult, error) {
-	if backupID == "" {
-		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration: backupID is required")
+	if a.backupUseCase == nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration: backup usecase is not initialized")
 	}
-
-	a.backupMu.Lock()
-	index, err := a.loadBackupIndexLocked()
+	result, err := a.backupUseCase.RestoreGeneration(a.ctx, backupID)
 	if err != nil {
-		a.backupMu.Unlock()
-		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration load index: %w", err)
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration: %w", err)
 	}
-	var target *backupIndexEntry
-	for i := range index.Generations {
-		if index.Generations[i].ID == backupID {
-			target = &index.Generations[i]
-			break
-		}
-	}
-	if target == nil {
-		a.backupMu.Unlock()
-		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration: 指定した世代が見つかりません")
-	}
-	src := filepath.Join(a.backupDir, target.FileName)
-	a.backupMu.Unlock()
-
-	restoreSourceTmp := a.dbPath + ".restore-source.tmp"
-	if err := copyFile(src, restoreSourceTmp); err != nil {
-		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration cache source: %w", err)
-	}
-	defer os.Remove(restoreSourceTmp)
-
-	preserved, err := a.runManagedBackup("before_restore")
-	if err != nil {
-		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration preserve current data: %w", err)
-	}
-
-	tmp := a.dbPath + ".restore.tmp"
-	if err := copyFile(restoreSourceTmp, tmp); err != nil {
-		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration copy: %w", err)
-	}
-	_ = os.Remove(a.dbPath)
-	if err := os.Rename(tmp, a.dbPath); err != nil {
-		_ = os.Remove(tmp)
-		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration replace: %w", err)
-	}
-
-	return entity.RestoreBackupResult{
-		Restored:          true,
-		BackupID:          backupID,
-		PreservedBackupID: preserved.ID,
-		RestartRequired:   true,
-	}, nil
-}
-
-func (a *App) loadBackupSettings() error {
-	a.backupMu.Lock()
-	defer a.backupMu.Unlock()
-
-	data, err := os.ReadFile(a.backupSettingsPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			a.backupSettings = defaultBackupSettings()
-			return a.persistBackupSettingsLocked()
-		}
-		return err
-	}
-
-	var settings entity.BackupSettings
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return err
-	}
-	a.backupSettings = normalizeBackupSettings(settings)
-	return nil
-}
-
-func (a *App) persistBackupSettingsLocked() error {
-	if err := os.MkdirAll(filepath.Dir(a.backupSettingsPath), 0755); err != nil {
-		return err
-	}
-	body, err := json.MarshalIndent(a.backupSettings, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := a.backupSettingsPath + ".tmp"
-	if err := os.WriteFile(tmp, body, 0644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, a.backupSettingsPath)
-}
-
-func (a *App) runManagedBackup(trigger string) (entity.BackupGeneration, error) {
-	a.backupMu.Lock()
-	backupDir := a.backupDir
-	maxGenerations := normalizeBackupSettings(a.backupSettings).MaxGenerations
-	a.backupMu.Unlock()
-
-	if err := os.MkdirAll(backupDir, 0755); err != nil {
-		return entity.BackupGeneration{}, err
-	}
-
-	now := time.Now()
-	backupID := fmt.Sprintf("bkp-%d", now.UnixNano())
-	fileName := fmt.Sprintf("atena-backup-%s-%s.db", now.Format("20060102-150405"), backupID)
-	dest := filepath.Join(backupDir, fileName)
-
-	_ = os.Remove(dest)
-	if _, err := a.db.ExecContext(a.ctx, "VACUUM INTO ?", dest); err != nil {
-		return entity.BackupGeneration{}, err
-	}
-
-	contactCount := 0
-	if err := a.db.QueryRowContext(a.ctx, "SELECT COUNT(*) FROM contacts").Scan(&contactCount); err != nil {
-		contactCount = 0
-	}
-
-	a.backupMu.Lock()
-	defer a.backupMu.Unlock()
-	index, err := a.loadBackupIndexLocked()
-	if err != nil {
-		return entity.BackupGeneration{}, err
-	}
-	index.Generations = append(index.Generations, backupIndexEntry{
-		ID:           backupID,
-		CreatedAt:    now,
-		ContactCount: contactCount,
-		Trigger:      trigger,
-		FileName:     fileName,
-	})
-	sort.Slice(index.Generations, func(i, j int) bool {
-		return index.Generations[i].CreatedAt.After(index.Generations[j].CreatedAt)
-	})
-	if len(index.Generations) > maxGenerations {
-		for _, old := range index.Generations[maxGenerations:] {
-			_ = os.Remove(filepath.Join(backupDir, old.FileName))
-		}
-		index.Generations = index.Generations[:maxGenerations]
-	}
-	if err := a.saveBackupIndexLocked(index); err != nil {
-		return entity.BackupGeneration{}, err
-	}
-
-	return entity.BackupGeneration{
-		ID:           backupID,
-		CreatedAt:    now,
-		ContactCount: contactCount,
-		Trigger:      trigger,
-	}, nil
-}
-
-func (a *App) loadBackupIndexLocked() (backupIndex, error) {
-	var idx backupIndex
-
-	data, err := os.ReadFile(a.backupIndexPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return backupIndex{Generations: []backupIndexEntry{}}, nil
-		}
-		return backupIndex{}, err
-	}
-	if err := json.Unmarshal(data, &idx); err != nil {
-		return backupIndex{}, err
-	}
-	if idx.Generations == nil {
-		idx.Generations = []backupIndexEntry{}
-	}
-	return idx, nil
-}
-
-func (a *App) saveBackupIndexLocked(idx backupIndex) error {
-	if err := os.MkdirAll(filepath.Dir(a.backupIndexPath), 0755); err != nil {
-		return err
-	}
-	body, err := json.MarshalIndent(idx, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := a.backupIndexPath + ".tmp"
-	if err := os.WriteFile(tmp, body, 0644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, a.backupIndexPath)
-}
-
-func (a *App) reconfigureBackupTicker() error {
-	a.backupMu.Lock()
-	settings := normalizeBackupSettings(a.backupSettings)
-	oldStop := a.backupTickerStop
-	oldDone := a.backupTickerDone
-	a.backupTickerStop = nil
-	a.backupTickerDone = nil
-
-	interval := settings.Timing.IntervalMinutes
-	var newStop chan struct{}
-	var newDone chan struct{}
-	if interval > 0 {
-		newStop = make(chan struct{})
-		newDone = make(chan struct{})
-		a.backupTickerStop = newStop
-		a.backupTickerDone = newDone
-	}
-	a.backupMu.Unlock()
-
-	if oldStop != nil {
-		close(oldStop)
-		if oldDone != nil {
-			<-oldDone
-		}
-	}
-
-	if interval <= 0 {
-		return nil
-	}
-
-	go func(intervalMinutes int, stop <-chan struct{}, done chan<- struct{}) {
-		ticker := time.NewTicker(time.Duration(intervalMinutes) * time.Minute)
-		defer ticker.Stop()
-		defer close(done)
-
-		for {
-			select {
-			case <-ticker.C:
-				if _, err := a.runManagedBackup("interval"); err != nil {
-					log.Printf("periodic backup failed: %v", err)
-				}
-			case <-stop:
-				return
-			}
-		}
-	}(interval, newStop, newDone)
-
-	return nil
-}
-
-func (a *App) stopBackupTicker() {
-	a.backupMu.Lock()
-	stop := a.backupTickerStop
-	done := a.backupTickerDone
-	a.backupTickerStop = nil
-	a.backupTickerDone = nil
-	a.backupMu.Unlock()
-
-	if stop != nil {
-		close(stop)
-	}
-	if done != nil {
-		<-done
-	}
-}
-
-func defaultBackupSettings() entity.BackupSettings {
-	return entity.BackupSettings{
-		Timing: entity.BackupTimingSettings{
-			OnStartup:       true,
-			OnShutdown:      true,
-			IntervalMinutes: defaultBackupIntervalMinutes,
-		},
-		MaxGenerations: defaultBackupMaxGenerations,
-	}
-}
-
-func normalizeBackupSettings(settings entity.BackupSettings) entity.BackupSettings {
-	normalized := settings
-	if normalized.MaxGenerations <= 0 {
-		normalized.MaxGenerations = defaultBackupMaxGenerations
-	}
-	if normalized.Timing.IntervalMinutes < 0 {
-		normalized.Timing.IntervalMinutes = defaultBackupIntervalMinutes
-	}
-	return normalized
+	return result, nil
 }
 
 func copyFile(src, dst string) error {

--- a/app.go
+++ b/app.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -20,6 +22,23 @@ import (
 
 // AppVersion はアプリのバージョン文字列。
 const AppVersion = "1.0.0"
+
+const (
+	defaultBackupIntervalMinutes = 0
+	defaultBackupMaxGenerations  = 20
+)
+
+type backupIndex struct {
+	Generations []backupIndexEntry `json:"generations"`
+}
+
+type backupIndexEntry struct {
+	ID           string    `json:"id"`
+	CreatedAt    time.Time `json:"createdAt"`
+	ContactCount int       `json:"contactCount"`
+	Trigger      string    `json:"trigger"`
+	FileName     string    `json:"fileName"`
+}
 
 // App struct
 type App struct {
@@ -39,6 +58,13 @@ type App struct {
 	dbPath              string
 	normMu              sync.Mutex
 	lastNormBatch       *addressNormalizationRollbackBatch
+	backupMu            sync.Mutex
+	backupSettings      entity.BackupSettings
+	backupSettingsPath  string
+	backupIndexPath     string
+	backupDir           string
+	backupTickerStop    chan struct{}
+	backupTickerDone    chan struct{}
 }
 
 type addressNormalizationRollbackBatch struct {
@@ -48,6 +74,7 @@ type addressNormalizationRollbackBatch struct {
 
 // NewApp creates a new App application struct
 func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.ContactYearStatusUseCase, csvUC *usecase.CSVUseCase, groupUC *usecase.GroupUseCase, watermarkUC *usecase.WatermarkUseCase, qrCodeUC *usecase.QRCodeUseCase, printUC *usecase.PrintUseCase, senderUC *usecase.SenderUseCase, postalRepo repository.PostalRepository, printHistoryUC *usecase.PrintHistoryUseCase, db *sql.DB, dbPath string) *App {
+	dataDir := filepath.Dir(dbPath)
 	return &App{
 		contactUseCase:      contactUC,
 		contactYearStatusUC: contactYearStatusUC,
@@ -62,6 +89,10 @@ func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.Cont
 		printHistoryUseCase: printHistoryUC,
 		db:                  db,
 		dbPath:              dbPath,
+		backupSettings:      defaultBackupSettings(),
+		backupSettingsPath:  filepath.Join(dataDir, "backup_settings.json"),
+		backupIndexPath:     filepath.Join(dataDir, "backup_index.json"),
+		backupDir:           filepath.Join(dataDir, "backups"),
 	}
 }
 
@@ -69,6 +100,41 @@ func NewApp(contactUC *usecase.ContactUseCase, contactYearStatusUC *usecase.Cont
 // so we can call the runtime methods
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
+
+	if err := a.loadBackupSettings(); err != nil {
+		log.Printf("backup settings load failed: %v", err)
+	}
+	if err := a.reconfigureBackupTicker(); err != nil {
+		log.Printf("backup scheduler start failed: %v", err)
+	}
+
+	settings, err := a.GetBackupSettings()
+	if err != nil {
+		log.Printf("backup settings read failed: %v", err)
+		return
+	}
+	if settings.Timing.OnStartup {
+		if _, err := a.runManagedBackup("startup"); err != nil {
+			log.Printf("startup backup failed: %v", err)
+		}
+	}
+}
+
+// shutdown is called right before the app terminates.
+func (a *App) shutdown(ctx context.Context) {
+	_ = ctx
+	a.stopBackupTicker()
+
+	settings, err := a.GetBackupSettings()
+	if err != nil {
+		log.Printf("backup settings read failed: %v", err)
+		return
+	}
+	if settings.Timing.OnShutdown {
+		if _, err := a.runManagedBackup("shutdown"); err != nil {
+			log.Printf("shutdown backup failed: %v", err)
+		}
+	}
 }
 
 // GetContacts returns all contacts, optionally filtered by groupID.
@@ -630,6 +696,355 @@ func (a *App) ImportDB() (bool, error) {
 		return false, fmt.Errorf("ImportDB 配置失敗: %w", err)
 	}
 	return true, nil
+}
+
+// GetBackupSettings returns current automatic backup settings.
+func (a *App) GetBackupSettings() (entity.BackupSettings, error) {
+	a.backupMu.Lock()
+	defer a.backupMu.Unlock()
+	return normalizeBackupSettings(a.backupSettings), nil
+}
+
+// SaveBackupSettings updates automatic backup settings and restarts scheduler.
+func (a *App) SaveBackupSettings(settings entity.BackupSettings) (entity.BackupSettings, error) {
+	normalized := normalizeBackupSettings(settings)
+
+	a.backupMu.Lock()
+	a.backupSettings = normalized
+	if err := a.persistBackupSettingsLocked(); err != nil {
+		a.backupMu.Unlock()
+		return entity.BackupSettings{}, fmt.Errorf("SaveBackupSettings: %w", err)
+	}
+	a.backupMu.Unlock()
+
+	if err := a.reconfigureBackupTicker(); err != nil {
+		return entity.BackupSettings{}, fmt.Errorf("SaveBackupSettings scheduler: %w", err)
+	}
+	return normalized, nil
+}
+
+// ListBackupGenerations returns restorable backup generations.
+func (a *App) ListBackupGenerations() ([]entity.BackupGeneration, error) {
+	a.backupMu.Lock()
+	index, err := a.loadBackupIndexLocked()
+	if err != nil {
+		a.backupMu.Unlock()
+		return nil, fmt.Errorf("ListBackupGenerations: %w", err)
+	}
+	filtered := make([]backupIndexEntry, 0, len(index.Generations))
+	changed := false
+	for _, entry := range index.Generations {
+		if entry.FileName == "" {
+			changed = true
+			continue
+		}
+		fullPath := filepath.Join(a.backupDir, entry.FileName)
+		if _, statErr := os.Stat(fullPath); statErr != nil {
+			if os.IsNotExist(statErr) {
+				changed = true
+				continue
+			}
+			a.backupMu.Unlock()
+			return nil, fmt.Errorf("ListBackupGenerations stat %s: %w", entry.FileName, statErr)
+		}
+		filtered = append(filtered, entry)
+	}
+	if changed {
+		index.Generations = filtered
+		if err := a.saveBackupIndexLocked(index); err != nil {
+			a.backupMu.Unlock()
+			return nil, fmt.Errorf("ListBackupGenerations cleanup index: %w", err)
+		}
+	}
+
+	list := make([]entity.BackupGeneration, 0, len(index.Generations))
+	for _, entry := range index.Generations {
+		list = append(list, entity.BackupGeneration{
+			ID:           entry.ID,
+			CreatedAt:    entry.CreatedAt,
+			ContactCount: entry.ContactCount,
+			Trigger:      entry.Trigger,
+		})
+	}
+	a.backupMu.Unlock()
+
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].CreatedAt.After(list[j].CreatedAt)
+	})
+	return list, nil
+}
+
+// RestoreBackupGeneration restores one backup generation.
+// The restored data is reflected after app restart.
+func (a *App) RestoreBackupGeneration(backupID string) (entity.RestoreBackupResult, error) {
+	if backupID == "" {
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration: backupID is required")
+	}
+
+	a.backupMu.Lock()
+	index, err := a.loadBackupIndexLocked()
+	if err != nil {
+		a.backupMu.Unlock()
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration load index: %w", err)
+	}
+	var target *backupIndexEntry
+	for i := range index.Generations {
+		if index.Generations[i].ID == backupID {
+			target = &index.Generations[i]
+			break
+		}
+	}
+	if target == nil {
+		a.backupMu.Unlock()
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration: 指定した世代が見つかりません")
+	}
+	src := filepath.Join(a.backupDir, target.FileName)
+	a.backupMu.Unlock()
+
+	restoreSourceTmp := a.dbPath + ".restore-source.tmp"
+	if err := copyFile(src, restoreSourceTmp); err != nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration cache source: %w", err)
+	}
+	defer os.Remove(restoreSourceTmp)
+
+	preserved, err := a.runManagedBackup("before_restore")
+	if err != nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration preserve current data: %w", err)
+	}
+
+	tmp := a.dbPath + ".restore.tmp"
+	if err := copyFile(restoreSourceTmp, tmp); err != nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration copy: %w", err)
+	}
+	_ = os.Remove(a.dbPath)
+	if err := os.Rename(tmp, a.dbPath); err != nil {
+		_ = os.Remove(tmp)
+		return entity.RestoreBackupResult{}, fmt.Errorf("RestoreBackupGeneration replace: %w", err)
+	}
+
+	return entity.RestoreBackupResult{
+		Restored:          true,
+		BackupID:          backupID,
+		PreservedBackupID: preserved.ID,
+		RestartRequired:   true,
+	}, nil
+}
+
+func (a *App) loadBackupSettings() error {
+	a.backupMu.Lock()
+	defer a.backupMu.Unlock()
+
+	data, err := os.ReadFile(a.backupSettingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			a.backupSettings = defaultBackupSettings()
+			return a.persistBackupSettingsLocked()
+		}
+		return err
+	}
+
+	var settings entity.BackupSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return err
+	}
+	a.backupSettings = normalizeBackupSettings(settings)
+	return nil
+}
+
+func (a *App) persistBackupSettingsLocked() error {
+	if err := os.MkdirAll(filepath.Dir(a.backupSettingsPath), 0755); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(a.backupSettings, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := a.backupSettingsPath + ".tmp"
+	if err := os.WriteFile(tmp, body, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, a.backupSettingsPath)
+}
+
+func (a *App) runManagedBackup(trigger string) (entity.BackupGeneration, error) {
+	a.backupMu.Lock()
+	backupDir := a.backupDir
+	maxGenerations := normalizeBackupSettings(a.backupSettings).MaxGenerations
+	a.backupMu.Unlock()
+
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		return entity.BackupGeneration{}, err
+	}
+
+	now := time.Now()
+	backupID := fmt.Sprintf("bkp-%d", now.UnixNano())
+	fileName := fmt.Sprintf("atena-backup-%s-%s.db", now.Format("20060102-150405"), backupID)
+	dest := filepath.Join(backupDir, fileName)
+
+	_ = os.Remove(dest)
+	if _, err := a.db.ExecContext(a.ctx, "VACUUM INTO ?", dest); err != nil {
+		return entity.BackupGeneration{}, err
+	}
+
+	contactCount := 0
+	if err := a.db.QueryRowContext(a.ctx, "SELECT COUNT(*) FROM contacts").Scan(&contactCount); err != nil {
+		contactCount = 0
+	}
+
+	a.backupMu.Lock()
+	defer a.backupMu.Unlock()
+	index, err := a.loadBackupIndexLocked()
+	if err != nil {
+		return entity.BackupGeneration{}, err
+	}
+	index.Generations = append(index.Generations, backupIndexEntry{
+		ID:           backupID,
+		CreatedAt:    now,
+		ContactCount: contactCount,
+		Trigger:      trigger,
+		FileName:     fileName,
+	})
+	sort.Slice(index.Generations, func(i, j int) bool {
+		return index.Generations[i].CreatedAt.After(index.Generations[j].CreatedAt)
+	})
+	if len(index.Generations) > maxGenerations {
+		for _, old := range index.Generations[maxGenerations:] {
+			_ = os.Remove(filepath.Join(backupDir, old.FileName))
+		}
+		index.Generations = index.Generations[:maxGenerations]
+	}
+	if err := a.saveBackupIndexLocked(index); err != nil {
+		return entity.BackupGeneration{}, err
+	}
+
+	return entity.BackupGeneration{
+		ID:           backupID,
+		CreatedAt:    now,
+		ContactCount: contactCount,
+		Trigger:      trigger,
+	}, nil
+}
+
+func (a *App) loadBackupIndexLocked() (backupIndex, error) {
+	var idx backupIndex
+
+	data, err := os.ReadFile(a.backupIndexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return backupIndex{Generations: []backupIndexEntry{}}, nil
+		}
+		return backupIndex{}, err
+	}
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return backupIndex{}, err
+	}
+	if idx.Generations == nil {
+		idx.Generations = []backupIndexEntry{}
+	}
+	return idx, nil
+}
+
+func (a *App) saveBackupIndexLocked(idx backupIndex) error {
+	if err := os.MkdirAll(filepath.Dir(a.backupIndexPath), 0755); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := a.backupIndexPath + ".tmp"
+	if err := os.WriteFile(tmp, body, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, a.backupIndexPath)
+}
+
+func (a *App) reconfigureBackupTicker() error {
+	a.backupMu.Lock()
+	settings := normalizeBackupSettings(a.backupSettings)
+	oldStop := a.backupTickerStop
+	oldDone := a.backupTickerDone
+	a.backupTickerStop = nil
+	a.backupTickerDone = nil
+
+	interval := settings.Timing.IntervalMinutes
+	var newStop chan struct{}
+	var newDone chan struct{}
+	if interval > 0 {
+		newStop = make(chan struct{})
+		newDone = make(chan struct{})
+		a.backupTickerStop = newStop
+		a.backupTickerDone = newDone
+	}
+	a.backupMu.Unlock()
+
+	if oldStop != nil {
+		close(oldStop)
+		if oldDone != nil {
+			<-oldDone
+		}
+	}
+
+	if interval <= 0 {
+		return nil
+	}
+
+	go func(intervalMinutes int, stop <-chan struct{}, done chan<- struct{}) {
+		ticker := time.NewTicker(time.Duration(intervalMinutes) * time.Minute)
+		defer ticker.Stop()
+		defer close(done)
+
+		for {
+			select {
+			case <-ticker.C:
+				if _, err := a.runManagedBackup("interval"); err != nil {
+					log.Printf("periodic backup failed: %v", err)
+				}
+			case <-stop:
+				return
+			}
+		}
+	}(interval, newStop, newDone)
+
+	return nil
+}
+
+func (a *App) stopBackupTicker() {
+	a.backupMu.Lock()
+	stop := a.backupTickerStop
+	done := a.backupTickerDone
+	a.backupTickerStop = nil
+	a.backupTickerDone = nil
+	a.backupMu.Unlock()
+
+	if stop != nil {
+		close(stop)
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func defaultBackupSettings() entity.BackupSettings {
+	return entity.BackupSettings{
+		Timing: entity.BackupTimingSettings{
+			OnStartup:       true,
+			OnShutdown:      true,
+			IntervalMinutes: defaultBackupIntervalMinutes,
+		},
+		MaxGenerations: defaultBackupMaxGenerations,
+	}
+}
+
+func normalizeBackupSettings(settings entity.BackupSettings) entity.BackupSettings {
+	normalized := settings
+	if normalized.MaxGenerations <= 0 {
+		normalized.MaxGenerations = defaultBackupMaxGenerations
+	}
+	if normalized.Timing.IntervalMinutes < 0 {
+		normalized.Timing.IntervalMinutes = defaultBackupIntervalMinutes
+	}
+	return normalized
 }
 
 func copyFile(src, dst string) error {

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,14 +1,49 @@
 import { useEffect, useState } from 'react'
-import { GetAppVersion, ExportDB, ImportDB } from '../../wailsjs/go/main/App'
+import {
+  ExportDB,
+  GetAppVersion,
+  GetBackupSettings,
+  ImportDB,
+  ListBackupGenerations,
+  RestoreBackupGeneration,
+  SaveBackupSettings,
+} from '../../wailsjs/go/main/App'
+import type { BackupGeneration, BackupSettings } from '../types'
+
+const triggerLabelMap: Record<string, string> = {
+  startup: '起動時',
+  shutdown: '終了時',
+  interval: '定期実行',
+  before_restore: '復元前退避',
+}
 
 export default function Settings() {
   const [version, setVersion] = useState('')
   const [exportMsg, setExportMsg] = useState('')
   const [importMsg, setImportMsg] = useState('')
+  const [backupSettings, setBackupSettings] = useState<BackupSettings | null>(null)
+  const [backupSettingsMsg, setBackupSettingsMsg] = useState('')
+  const [backupGenerations, setBackupGenerations] = useState<BackupGeneration[]>([])
+  const [restoreMsg, setRestoreMsg] = useState('')
+  const [loadingBackups, setLoadingBackups] = useState(false)
+  const [savingBackupSettings, setSavingBackupSettings] = useState(false)
+  const [restoringBackupID, setRestoringBackupID] = useState('')
 
   useEffect(() => {
     GetAppVersion().then(setVersion).catch(console.error)
+    loadBackupData().catch(console.error)
   }, [])
+
+  async function loadBackupData() {
+    setLoadingBackups(true)
+    try {
+      const [settings, generations] = await Promise.all([GetBackupSettings(), ListBackupGenerations()])
+      setBackupSettings(settings as BackupSettings)
+      setBackupGenerations(generations as BackupGeneration[])
+    } finally {
+      setLoadingBackups(false)
+    }
+  }
 
   async function handleExport() {
     setExportMsg('')
@@ -34,11 +69,58 @@ export default function Settings() {
     }
   }
 
+  async function handleSaveBackupSettings() {
+    if (!backupSettings) return
+    setBackupSettingsMsg('')
+    setSavingBackupSettings(true)
+    try {
+      const saved = await SaveBackupSettings(backupSettings)
+      setBackupSettings(saved as BackupSettings)
+      setBackupSettingsMsg('自動バックアップ設定を保存しました。')
+      await loadBackupData()
+    } catch (e) {
+      setBackupSettingsMsg(`保存エラー: ${e}`)
+    } finally {
+      setSavingBackupSettings(false)
+    }
+  }
+
+  async function handleRestoreGeneration(generation: BackupGeneration) {
+    const ok = window.confirm(
+      `世代 ${formatDateTime(generation.createdAt)} を復元します。\n復元前に現行データは自動退避されます。\n実行しますか？`,
+    )
+    if (!ok) return
+
+    setRestoreMsg('')
+    setRestoringBackupID(generation.id)
+    try {
+      const result = await RestoreBackupGeneration(generation.id)
+      const typed = result as { preservedBackupId?: string; restartRequired?: boolean }
+      const preserved = typed.preservedBackupId ? `（現行退避: ${typed.preservedBackupId}）` : ''
+      const restart = typed.restartRequired ? ' アプリ再起動後に反映されます。' : ''
+      setRestoreMsg(`復元しました ${preserved}.${restart}`.trim())
+      await loadBackupData()
+    } catch (e) {
+      setRestoreMsg(`復元エラー: ${e}`)
+    } finally {
+      setRestoringBackupID('')
+    }
+  }
+
+  function updateBackupSettings(next: Partial<BackupSettings>) {
+    setBackupSettings((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        ...next,
+      }
+    })
+  }
+
   return (
-    <div className="flex-1 overflow-y-auto p-6 space-y-8 max-w-xl">
+    <div className="flex-1 overflow-y-auto p-6 space-y-8 max-w-4xl">
       <h2 className="text-xl font-semibold text-gray-800">設定</h2>
 
-      {/* データ管理 */}
       <section className="space-y-3">
         <h3 className="text-sm font-semibold text-gray-600 border-b border-gray-200 pb-2">データ管理</h3>
 
@@ -61,15 +143,143 @@ export default function Settings() {
             </button>
           </div>
           {exportMsg && <p className="text-xs text-green-600">{exportMsg}</p>}
-          {importMsg && (
-            <p className="text-xs text-amber-600">
-              {importMsg}
-            </p>
-          )}
+          {importMsg && <p className="text-xs text-amber-600">{importMsg}</p>}
         </div>
       </section>
 
-      {/* バージョン情報 */}
+      <section className="space-y-4">
+        <h3 className="text-sm font-semibold text-gray-600 border-b border-gray-200 pb-2">自動バックアップ設定</h3>
+
+        {!backupSettings ? (
+          <p className="text-sm text-gray-500">設定を読み込み中...</p>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={backupSettings.timing.onStartup}
+                  onChange={(e) =>
+                    updateBackupSettings({
+                      timing: {
+                        ...backupSettings.timing,
+                        onStartup: e.target.checked,
+                      },
+                    })
+                  }
+                />
+                起動時に自動バックアップ
+              </label>
+
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={backupSettings.timing.onShutdown}
+                  onChange={(e) =>
+                    updateBackupSettings({
+                      timing: {
+                        ...backupSettings.timing,
+                        onShutdown: e.target.checked,
+                      },
+                    })
+                  }
+                />
+                終了時に自動バックアップ
+              </label>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="flex flex-col gap-1 text-sm text-gray-700">
+                定期バックアップ間隔 (分, 0で無効)
+                <input
+                  type="number"
+                  min={0}
+                  value={backupSettings.timing.intervalMinutes}
+                  onChange={(e) =>
+                    updateBackupSettings({
+                      timing: {
+                        ...backupSettings.timing,
+                        intervalMinutes: Number(e.target.value) || 0,
+                      },
+                    })
+                  }
+                  className="px-3 py-2 border border-gray-300 rounded-md"
+                />
+              </label>
+
+              <label className="flex flex-col gap-1 text-sm text-gray-700">
+                保持世代数
+                <input
+                  type="number"
+                  min={1}
+                  value={backupSettings.maxGenerations}
+                  onChange={(e) =>
+                    updateBackupSettings({
+                      maxGenerations: Math.max(1, Number(e.target.value) || 1),
+                    })
+                  }
+                  className="px-3 py-2 border border-gray-300 rounded-md"
+                />
+              </label>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleSaveBackupSettings}
+                disabled={savingBackupSettings}
+                className="px-4 py-2 text-sm rounded-md bg-emerald-600 text-white hover:bg-emerald-700 transition-colors disabled:bg-emerald-300"
+              >
+                {savingBackupSettings ? '保存中...' : '設定を保存'}
+              </button>
+              {backupSettingsMsg && <p className="text-xs text-green-700">{backupSettingsMsg}</p>}
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-gray-600 border-b border-gray-200 pb-2">バックアップ世代</h3>
+        <p className="text-sm text-gray-600">日時・件数を確認し、任意の世代へ復元できます。</p>
+
+        {loadingBackups ? (
+          <p className="text-sm text-gray-500">世代を読み込み中...</p>
+        ) : backupGenerations.length === 0 ? (
+          <p className="text-sm text-gray-500">バックアップ世代はまだありません。</p>
+        ) : (
+          <div className="overflow-x-auto border border-gray-200 rounded-md">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="text-left px-3 py-2">日時</th>
+                  <th className="text-left px-3 py-2">件数</th>
+                  <th className="text-left px-3 py-2">トリガー</th>
+                  <th className="text-right px-3 py-2">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {backupGenerations.map((generation) => (
+                  <tr key={generation.id} className="border-t border-gray-100">
+                    <td className="px-3 py-2 text-gray-800">{formatDateTime(generation.createdAt)}</td>
+                    <td className="px-3 py-2 text-gray-700">{generation.contactCount}件</td>
+                    <td className="px-3 py-2 text-gray-700">{triggerLabelMap[generation.trigger] ?? generation.trigger}</td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        onClick={() => handleRestoreGeneration(generation)}
+                        disabled={restoringBackupID === generation.id}
+                        className="px-3 py-1.5 text-xs rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:text-gray-400"
+                      >
+                        {restoringBackupID === generation.id ? '復元中...' : 'この世代へ復元'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {restoreMsg && <p className="text-xs text-amber-700">{restoreMsg}</p>}
+      </section>
+
       <section className="space-y-2">
         <h3 className="text-sm font-semibold text-gray-600 border-b border-gray-200 pb-2">バージョン情報</h3>
         <div className="text-sm text-gray-700 space-y-1">
@@ -87,4 +297,17 @@ export default function Settings() {
       </section>
     </div>
   )
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -234,4 +234,29 @@ export interface DashboardStats {
   groupCount: number
 }
 
+export interface BackupTimingSettings {
+  onStartup: boolean
+  onShutdown: boolean
+  intervalMinutes: number
+}
+
+export interface BackupSettings {
+  timing: BackupTimingSettings
+  maxGenerations: number
+}
+
+export interface BackupGeneration {
+  id: string
+  createdAt: string
+  contactCount: number
+  trigger: string
+}
+
+export interface RestoreBackupResult {
+  restored: boolean
+  backupId: string
+  preservedBackupId: string
+  restartRequired: boolean
+}
+
 export type View = 'dashboard' | 'contacts' | 'preview' | 'senders' | 'settings'

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -42,6 +42,8 @@ export function GetContacts(arg1:string):Promise<Array<entity.Contact>>;
 
 export function GetDashboardStats():Promise<entity.DashboardStats>;
 
+export function GetBackupSettings():Promise<any>;
+
 export function GetGroups():Promise<Array<entity.Group>>;
 
 export function GetPrintHistory(arg1:number):Promise<Array<entity.PrintHistory>>;
@@ -60,6 +62,8 @@ export function ImportDB():Promise<boolean>;
 
 export function LookupPostal(arg1:string):Promise<entity.Address>;
 
+export function ListBackupGenerations():Promise<any>;
+
 export function MarkContactsSentForYear(arg1:Array<string>,arg2:number):Promise<void>;
 
 export function OpenCSVFileDialog():Promise<string>;
@@ -69,6 +73,10 @@ export function PrintPDF(arg1:string):Promise<void>;
 export function RemoveContactFromGroup(arg1:string,arg2:string):Promise<void>;
 
 export function RollbackAddressNormalization(arg1:string):Promise<any>;
+
+export function RestoreBackupGeneration(arg1:string):Promise<any>;
+
+export function SaveBackupSettings(arg1:any):Promise<any>;
 
 export function SaveCSVFileDialog(arg1:string):Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -82,6 +82,10 @@ export function GetDashboardStats() {
   return window['go']['main']['App']['GetDashboardStats']();
 }
 
+export function GetBackupSettings() {
+  return window['go']['main']['App']['GetBackupSettings']();
+}
+
 export function GetGroups() {
   return window['go']['main']['App']['GetGroups']();
 }
@@ -118,6 +122,10 @@ export function LookupPostal(arg1) {
   return window['go']['main']['App']['LookupPostal'](arg1);
 }
 
+export function ListBackupGenerations() {
+  return window['go']['main']['App']['ListBackupGenerations']();
+}
+
 export function MarkContactsSentForYear(arg1, arg2) {
   return window['go']['main']['App']['MarkContactsSentForYear'](arg1, arg2);
 }
@@ -136,6 +144,14 @@ export function RemoveContactFromGroup(arg1, arg2) {
 
 export function RollbackAddressNormalization(arg1) {
   return window['go']['main']['App']['RollbackAddressNormalization'](arg1);
+}
+
+export function RestoreBackupGeneration(arg1) {
+  return window['go']['main']['App']['RestoreBackupGeneration'](arg1);
+}
+
+export function SaveBackupSettings(arg1) {
+  return window['go']['main']['App']['SaveBackupSettings'](arg1);
 }
 
 export function SaveCSVFileDialog(arg1) {

--- a/internal/entity/backup.go
+++ b/internal/entity/backup.go
@@ -1,0 +1,32 @@
+package entity
+
+import "time"
+
+// BackupTimingSettings defines automatic backup triggers.
+type BackupTimingSettings struct {
+	OnStartup       bool `json:"onStartup"`
+	OnShutdown      bool `json:"onShutdown"`
+	IntervalMinutes int  `json:"intervalMinutes"`
+}
+
+// BackupSettings defines configurable backup behavior.
+type BackupSettings struct {
+	Timing         BackupTimingSettings `json:"timing"`
+	MaxGenerations int                  `json:"maxGenerations"`
+}
+
+// BackupGeneration is one restorable backup snapshot.
+type BackupGeneration struct {
+	ID           string    `json:"id"`
+	CreatedAt    time.Time `json:"createdAt"`
+	ContactCount int       `json:"contactCount"`
+	Trigger      string    `json:"trigger"`
+}
+
+// RestoreBackupResult summarizes restore execution.
+type RestoreBackupResult struct {
+	Restored          bool   `json:"restored"`
+	BackupID          string `json:"backupId"`
+	PreservedBackupID string `json:"preservedBackupId"`
+	RestartRequired   bool   `json:"restartRequired"`
+}

--- a/internal/entity/backup.go
+++ b/internal/entity/backup.go
@@ -23,6 +23,22 @@ type BackupGeneration struct {
 	Trigger      string    `json:"trigger"`
 }
 
+// BackupGenerationRecord stores generation metadata with backing file info.
+type BackupGenerationRecord struct {
+	ID           string    `json:"id"`
+	CreatedAt    time.Time `json:"createdAt"`
+	ContactCount int       `json:"contactCount"`
+	Trigger      string    `json:"trigger"`
+	FileName     string    `json:"fileName"`
+}
+
+// PendingRestore represents a restore request applied on next startup.
+type PendingRestore struct {
+	BackupID    string    `json:"backupId"`
+	SourcePath  string    `json:"sourcePath"`
+	RequestedAt time.Time `json:"requestedAt"`
+}
+
 // RestoreBackupResult summarizes restore execution.
 type RestoreBackupResult struct {
 	Restored          bool   `json:"restored"`

--- a/internal/infrastructure/sqlite/backup_repo.go
+++ b/internal/infrastructure/sqlite/backup_repo.go
@@ -1,0 +1,213 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"atena-label/internal/entity"
+	"atena-label/internal/repository"
+)
+
+type backupIndex struct {
+	Generations []entity.BackupGenerationRecord `json:"generations"`
+}
+
+type BackupRepo struct {
+	db            *sql.DB
+	settingsPath  string
+	indexPath     string
+	backupDir     string
+	pendingDir    string
+	pendingMarker string
+}
+
+func NewBackupRepo(db *sql.DB, dataDir string) repository.BackupRepository {
+	return &BackupRepo{
+		db:            db,
+		settingsPath:  filepath.Join(dataDir, "backup_settings.json"),
+		indexPath:     filepath.Join(dataDir, "backup_index.json"),
+		backupDir:     filepath.Join(dataDir, "backups"),
+		pendingDir:    filepath.Join(dataDir, "pending_restore"),
+		pendingMarker: filepath.Join(dataDir, "pending_restore.json"),
+	}
+}
+
+func (r *BackupRepo) LoadSettings() (entity.BackupSettings, error) {
+	var settings entity.BackupSettings
+	body, err := os.ReadFile(r.settingsPath)
+	if err != nil {
+		return entity.BackupSettings{}, err
+	}
+	if err := json.Unmarshal(body, &settings); err != nil {
+		return entity.BackupSettings{}, err
+	}
+	return settings, nil
+}
+
+func (r *BackupRepo) SaveSettings(settings entity.BackupSettings) error {
+	return writeJSONAtomic(r.settingsPath, settings)
+}
+
+func (r *BackupRepo) LoadGenerationRecords() ([]entity.BackupGenerationRecord, error) {
+	body, err := os.ReadFile(r.indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []entity.BackupGenerationRecord{}, nil
+		}
+		return nil, err
+	}
+	var idx backupIndex
+	if err := json.Unmarshal(body, &idx); err != nil {
+		return nil, err
+	}
+	if idx.Generations == nil {
+		return []entity.BackupGenerationRecord{}, nil
+	}
+	return idx.Generations, nil
+}
+
+func (r *BackupRepo) SaveGenerationRecords(records []entity.BackupGenerationRecord) error {
+	if records == nil {
+		records = []entity.BackupGenerationRecord{}
+	}
+	return writeJSONAtomic(r.indexPath, backupIndex{Generations: records})
+}
+
+func (r *BackupRepo) CreateSnapshot(ctx context.Context, destPath string) error {
+	_ = os.Remove(destPath)
+	if _, err := r.db.ExecContext(ctx, "VACUUM INTO ?", destPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *BackupRepo) CountContacts(ctx context.Context) (int, error) {
+	var count int
+	if err := r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM contacts").Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (r *BackupRepo) BackupFilePath(fileName string) string {
+	return filepath.Join(r.backupDir, fileName)
+}
+
+func (r *BackupRepo) BackupFileExists(fileName string) (bool, error) {
+	_, err := os.Stat(r.BackupFilePath(fileName))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (r *BackupRepo) RemoveBackupFile(fileName string) error {
+	err := os.Remove(r.BackupFilePath(fileName))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *BackupRepo) StagePendingRestore(fileName string, backupID string) (entity.PendingRestore, error) {
+	src := r.BackupFilePath(fileName)
+	if _, err := os.Stat(src); err != nil {
+		return entity.PendingRestore{}, err
+	}
+	if err := os.MkdirAll(r.pendingDir, 0755); err != nil {
+		return entity.PendingRestore{}, err
+	}
+
+	staged := filepath.Join(r.pendingDir, fmt.Sprintf("restore-%d.db", time.Now().UnixNano()))
+	if err := copyFile(src, staged); err != nil {
+		return entity.PendingRestore{}, err
+	}
+	pending := entity.PendingRestore{
+		BackupID:    backupID,
+		SourcePath:  staged,
+		RequestedAt: time.Now(),
+	}
+	if err := writeJSONAtomic(r.pendingMarker, pending); err != nil {
+		_ = os.Remove(staged)
+		return entity.PendingRestore{}, err
+	}
+	return pending, nil
+}
+
+func PendingRestoreMarkerPath(dataDir string) string {
+	return filepath.Join(dataDir, "pending_restore.json")
+}
+
+func ApplyPendingRestore(dataDir string, dbPath string) error {
+	markerPath := PendingRestoreMarkerPath(dataDir)
+	body, err := os.ReadFile(markerPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var pending entity.PendingRestore
+	if err := json.Unmarshal(body, &pending); err != nil {
+		return err
+	}
+	if pending.SourcePath == "" {
+		return nil
+	}
+
+	tmp := dbPath + ".pending-restore.tmp"
+	if err := copyFile(pending.SourcePath, tmp); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, dbPath); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	_ = os.Remove(pending.SourcePath)
+	_ = os.Remove(markerPath)
+	return nil
+}
+
+func writeJSONAtomic(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}

--- a/internal/infrastructure/sqlite/backup_repo.go
+++ b/internal/infrastructure/sqlite/backup_repo.go
@@ -80,6 +80,9 @@ func (r *BackupRepo) SaveGenerationRecords(records []entity.BackupGenerationReco
 }
 
 func (r *BackupRepo) CreateSnapshot(ctx context.Context, destPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
 	_ = os.Remove(destPath)
 	if _, err := r.db.ExecContext(ctx, "VACUUM INTO ?", destPath); err != nil {
 		return err

--- a/internal/repository/backup_repository.go
+++ b/internal/repository/backup_repository.go
@@ -1,0 +1,24 @@
+package repository
+
+import (
+	"context"
+
+	"atena-label/internal/entity"
+)
+
+type BackupRepository interface {
+	LoadSettings() (entity.BackupSettings, error)
+	SaveSettings(settings entity.BackupSettings) error
+
+	LoadGenerationRecords() ([]entity.BackupGenerationRecord, error)
+	SaveGenerationRecords(records []entity.BackupGenerationRecord) error
+
+	CreateSnapshot(ctx context.Context, destPath string) error
+	CountContacts(ctx context.Context) (int, error)
+
+	BackupFilePath(fileName string) string
+	BackupFileExists(fileName string) (bool, error)
+	RemoveBackupFile(fileName string) error
+
+	StagePendingRestore(fileName string, backupID string) (entity.PendingRestore, error)
+}

--- a/internal/usecase/backup_usecase.go
+++ b/internal/usecase/backup_usecase.go
@@ -1,0 +1,323 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"atena-label/internal/entity"
+	"atena-label/internal/repository"
+)
+
+const (
+	defaultBackupIntervalMinutes = 0
+	defaultBackupMaxGenerations  = 20
+)
+
+type BackupUseCase struct {
+	repo repository.BackupRepository
+
+	mu       sync.Mutex
+	settings entity.BackupSettings
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+}
+
+func NewBackupUseCase(repo repository.BackupRepository) *BackupUseCase {
+	return &BackupUseCase{
+		repo:     repo,
+		settings: defaultBackupSettings(),
+	}
+}
+
+func (uc *BackupUseCase) Startup(ctx context.Context) error {
+	if err := uc.loadSettings(); err != nil {
+		return fmt.Errorf("load settings: %w", err)
+	}
+	if err := uc.reconfigureTicker(); err != nil {
+		return fmt.Errorf("start ticker: %w", err)
+	}
+	settings, err := uc.GetSettings()
+	if err != nil {
+		return fmt.Errorf("read settings: %w", err)
+	}
+	if settings.Timing.OnStartup {
+		if _, err := uc.runManagedBackup(ctx, "startup"); err != nil {
+			return fmt.Errorf("startup backup: %w", err)
+		}
+	}
+	return nil
+}
+
+func (uc *BackupUseCase) Shutdown(ctx context.Context) error {
+	uc.stopTicker()
+	settings, err := uc.GetSettings()
+	if err != nil {
+		return fmt.Errorf("read settings: %w", err)
+	}
+	if settings.Timing.OnShutdown {
+		if _, err := uc.runManagedBackup(ctx, "shutdown"); err != nil {
+			return fmt.Errorf("shutdown backup: %w", err)
+		}
+	}
+	return nil
+}
+
+func (uc *BackupUseCase) GetSettings() (entity.BackupSettings, error) {
+	uc.mu.Lock()
+	defer uc.mu.Unlock()
+	return normalizeBackupSettings(uc.settings), nil
+}
+
+func (uc *BackupUseCase) SaveSettings(settings entity.BackupSettings) (entity.BackupSettings, error) {
+	normalized := normalizeBackupSettings(settings)
+
+	uc.mu.Lock()
+	uc.settings = normalized
+	uc.mu.Unlock()
+
+	if err := uc.repo.SaveSettings(normalized); err != nil {
+		return entity.BackupSettings{}, fmt.Errorf("save settings: %w", err)
+	}
+	if err := uc.reconfigureTicker(); err != nil {
+		return entity.BackupSettings{}, fmt.Errorf("reconfigure ticker: %w", err)
+	}
+	return normalized, nil
+}
+
+func (uc *BackupUseCase) ListGenerations() ([]entity.BackupGeneration, error) {
+	records, err := uc.repo.LoadGenerationRecords()
+	if err != nil {
+		return nil, fmt.Errorf("load generations: %w", err)
+	}
+	filtered := make([]entity.BackupGenerationRecord, 0, len(records))
+	changed := false
+	for _, record := range records {
+		if record.FileName == "" {
+			changed = true
+			continue
+		}
+		exists, err := uc.repo.BackupFileExists(record.FileName)
+		if err != nil {
+			return nil, fmt.Errorf("check backup file %s: %w", record.FileName, err)
+		}
+		if !exists {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+	if changed {
+		if err := uc.repo.SaveGenerationRecords(filtered); err != nil {
+			return nil, fmt.Errorf("save cleaned generations: %w", err)
+		}
+	}
+	out := make([]entity.BackupGeneration, 0, len(filtered))
+	for _, record := range filtered {
+		out = append(out, entity.BackupGeneration{
+			ID:           record.ID,
+			CreatedAt:    record.CreatedAt,
+			ContactCount: record.ContactCount,
+			Trigger:      record.Trigger,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
+func (uc *BackupUseCase) RestoreGeneration(ctx context.Context, backupID string) (entity.RestoreBackupResult, error) {
+	if backupID == "" {
+		return entity.RestoreBackupResult{}, fmt.Errorf("backupID is required")
+	}
+	preserved, err := uc.runManagedBackup(ctx, "before_restore")
+	if err != nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("preserve current data: %w", err)
+	}
+
+	records, err := uc.repo.LoadGenerationRecords()
+	if err != nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("load generations: %w", err)
+	}
+	var target *entity.BackupGenerationRecord
+	for i := range records {
+		if records[i].ID == backupID {
+			target = &records[i]
+			break
+		}
+	}
+	if target == nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("指定した世代が見つかりません")
+	}
+
+	if _, err := uc.repo.StagePendingRestore(target.FileName, backupID); err != nil {
+		return entity.RestoreBackupResult{}, fmt.Errorf("stage pending restore: %w", err)
+	}
+	return entity.RestoreBackupResult{
+		Restored:          true,
+		BackupID:          backupID,
+		PreservedBackupID: preserved.ID,
+		RestartRequired:   true,
+	}, nil
+}
+
+func (uc *BackupUseCase) loadSettings() error {
+	settings, err := uc.repo.LoadSettings()
+	if err != nil {
+		if os.IsNotExist(err) {
+			defaults := defaultBackupSettings()
+			if saveErr := uc.repo.SaveSettings(defaults); saveErr != nil {
+				return saveErr
+			}
+			uc.mu.Lock()
+			uc.settings = defaults
+			uc.mu.Unlock()
+			return nil
+		}
+		return err
+	}
+	uc.mu.Lock()
+	uc.settings = normalizeBackupSettings(settings)
+	uc.mu.Unlock()
+	return nil
+}
+
+func (uc *BackupUseCase) runManagedBackup(ctx context.Context, trigger string) (entity.BackupGeneration, error) {
+	uc.mu.Lock()
+	settings := normalizeBackupSettings(uc.settings)
+	uc.mu.Unlock()
+
+	now := time.Now()
+	backupID := fmt.Sprintf("bkp-%d", now.UnixNano())
+	fileName := fmt.Sprintf("atena-backup-%s-%s.db", now.Format("20060102-150405"), backupID)
+	destPath := uc.repo.BackupFilePath(fileName)
+
+	if err := uc.repo.CreateSnapshot(ctx, destPath); err != nil {
+		return entity.BackupGeneration{}, err
+	}
+	contactCount, err := uc.repo.CountContacts(ctx)
+	if err != nil {
+		contactCount = 0
+	}
+
+	records, err := uc.repo.LoadGenerationRecords()
+	if err != nil {
+		return entity.BackupGeneration{}, err
+	}
+	records = append(records, entity.BackupGenerationRecord{
+		ID:           backupID,
+		CreatedAt:    now,
+		ContactCount: contactCount,
+		Trigger:      trigger,
+		FileName:     fileName,
+	})
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].CreatedAt.After(records[j].CreatedAt)
+	})
+	if len(records) > settings.MaxGenerations {
+		for _, old := range records[settings.MaxGenerations:] {
+			_ = uc.repo.RemoveBackupFile(old.FileName)
+		}
+		records = records[:settings.MaxGenerations]
+	}
+	if err := uc.repo.SaveGenerationRecords(records); err != nil {
+		return entity.BackupGeneration{}, err
+	}
+	return entity.BackupGeneration{
+		ID:           backupID,
+		CreatedAt:    now,
+		ContactCount: contactCount,
+		Trigger:      trigger,
+	}, nil
+}
+
+func (uc *BackupUseCase) reconfigureTicker() error {
+	uc.mu.Lock()
+	settings := normalizeBackupSettings(uc.settings)
+	oldStop := uc.stopCh
+	oldDone := uc.doneCh
+	uc.stopCh = nil
+	uc.doneCh = nil
+
+	interval := settings.Timing.IntervalMinutes
+	var newStop chan struct{}
+	var newDone chan struct{}
+	if interval > 0 {
+		newStop = make(chan struct{})
+		newDone = make(chan struct{})
+		uc.stopCh = newStop
+		uc.doneCh = newDone
+	}
+	uc.mu.Unlock()
+
+	if oldStop != nil {
+		close(oldStop)
+		if oldDone != nil {
+			<-oldDone
+		}
+	}
+	if interval <= 0 {
+		return nil
+	}
+
+	go func(intervalMinutes int, stop <-chan struct{}, done chan<- struct{}) {
+		ticker := time.NewTicker(time.Duration(intervalMinutes) * time.Minute)
+		defer ticker.Stop()
+		defer close(done)
+
+		for {
+			select {
+			case <-ticker.C:
+				if _, err := uc.runManagedBackup(context.Background(), "interval"); err != nil {
+					log.Printf("periodic backup failed: %v", err)
+				}
+			case <-stop:
+				return
+			}
+		}
+	}(interval, newStop, newDone)
+	return nil
+}
+
+func (uc *BackupUseCase) stopTicker() {
+	uc.mu.Lock()
+	stop := uc.stopCh
+	done := uc.doneCh
+	uc.stopCh = nil
+	uc.doneCh = nil
+	uc.mu.Unlock()
+
+	if stop != nil {
+		close(stop)
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func defaultBackupSettings() entity.BackupSettings {
+	return entity.BackupSettings{
+		Timing: entity.BackupTimingSettings{
+			OnStartup:       true,
+			OnShutdown:      true,
+			IntervalMinutes: defaultBackupIntervalMinutes,
+		},
+		MaxGenerations: defaultBackupMaxGenerations,
+	}
+}
+
+func normalizeBackupSettings(settings entity.BackupSettings) entity.BackupSettings {
+	normalized := settings
+	if normalized.MaxGenerations <= 0 {
+		normalized.MaxGenerations = defaultBackupMaxGenerations
+	}
+	if normalized.Timing.IntervalMinutes < 0 {
+		normalized.Timing.IntervalMinutes = defaultBackupIntervalMinutes
+	}
+	return normalized
+}

--- a/internal/usecase/backup_usecase.go
+++ b/internal/usecase/backup_usecase.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"atena-label/internal/entity"
 	"atena-label/internal/repository"
 )
@@ -22,6 +24,7 @@ type BackupUseCase struct {
 	repo repository.BackupRepository
 
 	mu       sync.Mutex
+	genMu    sync.Mutex
 	settings entity.BackupSettings
 	stopCh   chan struct{}
 	doneCh   chan struct{}
@@ -90,6 +93,9 @@ func (uc *BackupUseCase) SaveSettings(settings entity.BackupSettings) (entity.Ba
 }
 
 func (uc *BackupUseCase) ListGenerations() ([]entity.BackupGeneration, error) {
+	uc.genMu.Lock()
+	defer uc.genMu.Unlock()
+
 	records, err := uc.repo.LoadGenerationRecords()
 	if err != nil {
 		return nil, fmt.Errorf("load generations: %w", err)
@@ -140,8 +146,10 @@ func (uc *BackupUseCase) RestoreGeneration(ctx context.Context, backupID string)
 		return entity.RestoreBackupResult{}, fmt.Errorf("preserve current data: %w", err)
 	}
 
+	uc.genMu.Lock()
 	records, err := uc.repo.LoadGenerationRecords()
 	if err != nil {
+		uc.genMu.Unlock()
 		return entity.RestoreBackupResult{}, fmt.Errorf("load generations: %w", err)
 	}
 	var target *entity.BackupGenerationRecord
@@ -152,12 +160,15 @@ func (uc *BackupUseCase) RestoreGeneration(ctx context.Context, backupID string)
 		}
 	}
 	if target == nil {
+		uc.genMu.Unlock()
 		return entity.RestoreBackupResult{}, fmt.Errorf("指定した世代が見つかりません")
 	}
-
 	if _, err := uc.repo.StagePendingRestore(target.FileName, backupID); err != nil {
+		uc.genMu.Unlock()
 		return entity.RestoreBackupResult{}, fmt.Errorf("stage pending restore: %w", err)
 	}
+	uc.genMu.Unlock()
+
 	return entity.RestoreBackupResult{
 		Restored:          true,
 		BackupID:          backupID,
@@ -193,7 +204,7 @@ func (uc *BackupUseCase) runManagedBackup(ctx context.Context, trigger string) (
 	uc.mu.Unlock()
 
 	now := time.Now()
-	backupID := fmt.Sprintf("bkp-%d", now.UnixNano())
+	backupID := uuid.NewString()
 	fileName := fmt.Sprintf("atena-backup-%s-%s.db", now.Format("20060102-150405"), backupID)
 	destPath := uc.repo.BackupFilePath(fileName)
 
@@ -204,6 +215,9 @@ func (uc *BackupUseCase) runManagedBackup(ctx context.Context, trigger string) (
 	if err != nil {
 		contactCount = 0
 	}
+
+	uc.genMu.Lock()
+	defer uc.genMu.Unlock()
 
 	records, err := uc.repo.LoadGenerationRecords()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 		},
 		BackgroundColour: &options.RGBA{R: 255, G: 255, B: 255, A: 1},
 		OnStartup:        app.startup,
+		OnShutdown:       app.shutdown,
 		Bind: []interface{}{
 			app,
 		},

--- a/main.go
+++ b/main.go
@@ -29,7 +29,12 @@ func main() {
 		log.Fatal("data dir:", err)
 	}
 
-	db, err := dbpkg.Open(filepath.Join(appDataDir, "atena.db"))
+	dbPath := filepath.Join(appDataDir, "atena.db")
+	if err := dbpkg.ApplyPendingRestore(appDataDir, dbPath); err != nil {
+		log.Fatal("Apply pending restore:", err)
+	}
+
+	db, err := dbpkg.Open(dbPath)
 	if err != nil {
 		log.Fatal("Open DB:", err)
 	}
@@ -54,9 +59,10 @@ func main() {
 	printHistoryRepo := dbpkg.NewPrintHistoryRepo(db)
 	printHistoryUC := usecase.NewPrintHistoryUseCase(printHistoryRepo)
 
-	dbPath := filepath.Join(appDataDir, "atena.db")
+	backupRepo := dbpkg.NewBackupRepo(db, appDataDir)
+	backupUC := usecase.NewBackupUseCase(backupRepo)
 	postalRepo := postal.NewRepo()
-	app := NewApp(contactUC, contactYearStatusUC, csvUC, groupUC, watermarkUC, qrCodeUC, printUC, senderUC, postalRepo, printHistoryUC, db, dbPath)
+	app := NewApp(contactUC, contactYearStatusUC, csvUC, groupUC, watermarkUC, qrCodeUC, printUC, senderUC, postalRepo, printHistoryUC, backupUC, db, dbPath)
 
 	err = wails.Run(&options.App{
 		Title:  "Atena ラベル印刷",


### PR DESCRIPTION
## 概要
- 自動バックアップ設定（起動時/終了時/定期/保持世代）を追加
- バックアップ世代一覧（日時・件数・トリガー）を追加
- 任意世代への復元を追加（復元前に現行データを自動退避）

## 変更内容
- `app.go`
  - バックアップ設定の保存/取得 API を追加
  - 起動時・終了時・定期実行の自動バックアップを実装
  - 世代インデックス管理と保持世代のローテーションを実装
  - 世代一覧 API と世代復元 API を追加
- `main.go`
  - `OnShutdown` を追加し終了時バックアップを有効化
- `internal/entity/backup.go`
  - バックアップ関連エンティティを追加
- `frontend/src/components/Settings.tsx`
  - 自動バックアップ設定 UI、世代一覧 UI、復元操作 UI を追加
- `frontend/src/types.ts`
  - バックアップ関連型を追加
- `frontend/wailsjs/go/main/App.js`, `frontend/wailsjs/go/main/App.d.ts`
  - 新規 API バインディングを追加

## テスト
- `go test ./...`
- `npm --prefix frontend run build`
- `npm --prefix frontend run test:run`

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 自動バックアップ機能を追加。起動時・シャットダウン時・定期実行が選択可能。
  * バックアップ設定画面を追加し、保持世代数や間隔を設定可能。
  * バックアップ世代の一覧表示、世代ごとの復元機能を提供。
  * 起動時の保留復元適用や手動バックアップ実行、古い世代の自動削除をサポート。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->