### PR TITLE
[#79] 住所録一覧の視認性改善と幅調整機能を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
 import { useShallow } from 'zustand/shallow'
 import type { View } from './types'
 import ContactList from './components/address/ContactList'
@@ -14,8 +14,15 @@ import { useLabelStore } from './stores/labelStore'
 import { useContactStore } from './stores/contactStore'
 
 function App() {
+  const minContactPaneWidth = 300
+  const defaultContactPaneWidth = 360
+
   const [view, setView] = useState<View>('dashboard')
   const [showPrintDialog, setShowPrintDialog] = useState(false)
+  const [contactPaneWidth, setContactPaneWidth] = useState(defaultContactPaneWidth)
+  const [isResizingContactPane, setIsResizingContactPane] = useState(false)
+
+  const contactPaneResizeRef = useRef<{ startX: number; startWidth: number } | null>(null)
 
   const { showDecoPanel, toggleDecoPanel } = useDecorationStore(
     useShallow((s) => ({ showDecoPanel: s.showDecoPanel, toggleDecoPanel: s.toggleDecoPanel })),
@@ -40,6 +47,43 @@ function App() {
   )
 
   const showPreview = view === 'contacts' || view === 'preview'
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent) => {
+      const resizing = contactPaneResizeRef.current
+      if (!resizing) return
+      const rawNextWidth = resizing.startWidth + (event.clientX - resizing.startX)
+      const maxWidth = Math.max(minContactPaneWidth, window.innerWidth - 520)
+      const nextWidth = Math.min(maxWidth, Math.max(minContactPaneWidth, rawNextWidth))
+      setContactPaneWidth(nextWidth)
+    }
+    const handlePointerUp = () => {
+      contactPaneResizeRef.current = null
+      setIsResizingContactPane(false)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+  }, [])
+
+  const startContactPaneResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    contactPaneResizeRef.current = {
+      startX: event.clientX,
+      startWidth: contactPaneWidth,
+    }
+    setIsResizingContactPane(true)
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }
+
   const handleJumpToContact = (contactID: string) => {
     setShowPrintDialog(false)
     setView('contacts')
@@ -77,8 +121,22 @@ function App() {
           <Dashboard onNavigate={(v) => setView(v as View)} />
         )}
         {view === 'contacts' && (
-          <div className="w-72 border-r border-gray-200 bg-white flex flex-col h-full">
+          <div
+            className="relative border-r border-gray-200 bg-white flex flex-col h-full shrink-0"
+            style={{ width: contactPaneWidth, minWidth: minContactPaneWidth }}
+          >
             <ContactList />
+            <button
+              type="button"
+              onPointerDown={startContactPaneResize}
+              className={`absolute right-0 top-0 z-30 h-full w-2 translate-x-1/2 cursor-col-resize touch-none ${
+                isResizingContactPane ? 'bg-blue-200/70' : 'hover:bg-blue-100/70'
+              }`}
+              aria-label="住所録パネルの幅を調整"
+              title="ドラッグして住所録パネルを広げる"
+            >
+              <span className="mx-auto block h-full w-px bg-gray-300" />
+            </button>
           </div>
         )}
         {showPreview && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,11 @@ function App() {
 
   const showPreview = view === 'contacts' || view === 'preview'
   useEffect(() => {
+    const clampContactPaneWidth = () => {
+      const maxWidth = Math.max(minContactPaneWidth, window.innerWidth - 520)
+      setContactPaneWidth((prev) => Math.min(maxWidth, Math.max(minContactPaneWidth, prev)))
+    }
+
     const handlePointerMove = (event: PointerEvent) => {
       const resizing = contactPaneResizeRef.current
       if (!resizing) return
@@ -62,11 +67,14 @@ function App() {
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }
+    clampContactPaneWidth()
     window.addEventListener('pointermove', handlePointerMove)
     window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('resize', clampContactPaneWidth)
     return () => {
       window.removeEventListener('pointermove', handlePointerMove)
       window.removeEventListener('pointerup', handlePointerUp)
+      window.removeEventListener('resize', clampContactPaneWidth)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -8,6 +8,7 @@ import {
   RestoreBackupGeneration,
   SaveBackupSettings,
 } from '../../wailsjs/go/main/App'
+import { entity } from '../../wailsjs/go/models'
 import type { BackupGeneration, BackupSettings } from '../types'
 
 const triggerLabelMap: Record<string, string> = {
@@ -38,8 +39,24 @@ export default function Settings() {
     setLoadingBackups(true)
     try {
       const [settings, generations] = await Promise.all([GetBackupSettings(), ListBackupGenerations()])
-      setBackupSettings(settings as BackupSettings)
-      setBackupGenerations(generations as BackupGeneration[])
+      const typedSettings = settings as entity.BackupSettings
+      setBackupSettings({
+        timing: {
+          onStartup: typedSettings.timing?.onStartup ?? true,
+          onShutdown: typedSettings.timing?.onShutdown ?? true,
+          intervalMinutes: typedSettings.timing?.intervalMinutes ?? 0,
+        },
+        maxGenerations: typedSettings.maxGenerations ?? 20,
+      })
+      const typedGenerations = generations as entity.BackupGeneration[]
+      setBackupGenerations(
+        typedGenerations.map((generation) => ({
+          id: generation.id,
+          createdAt: String(generation.createdAt ?? ''),
+          contactCount: generation.contactCount,
+          trigger: generation.trigger,
+        })),
+      )
     } finally {
       setLoadingBackups(false)
     }
@@ -74,8 +91,17 @@ export default function Settings() {
     setBackupSettingsMsg('')
     setSavingBackupSettings(true)
     try {
-      const saved = await SaveBackupSettings(backupSettings)
-      setBackupSettings(saved as BackupSettings)
+      const payload = new entity.BackupSettings(backupSettings)
+      const saved = await SaveBackupSettings(payload)
+      const typed = saved as entity.BackupSettings
+      setBackupSettings({
+        timing: {
+          onStartup: typed.timing?.onStartup ?? true,
+          onShutdown: typed.timing?.onShutdown ?? true,
+          intervalMinutes: typed.timing?.intervalMinutes ?? 0,
+        },
+        maxGenerations: typed.maxGenerations ?? 20,
+      })
       setBackupSettingsMsg('自動バックアップ設定を保存しました。')
       await loadBackupData()
     } catch (e) {

--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -100,6 +100,19 @@ export default function ContactList() {
   const getCellKey = (contactId: string, field: EditableField) => `${contactId}:${field}`
 
   const getFieldValue = (contact: Contact, field: EditableField) => contact[field] ?? ''
+  const getDisplayName = (contact: Contact) => {
+    const fullName = `${contact.familyName}${contact.givenName}`.trim()
+    if (fullName) return fullName
+    const company = contact.company.trim()
+    if (company) return company
+    return '名称未設定'
+  }
+  const getDisplayAddress = (contact: Contact) => {
+    const address = `${contact.prefecture}${contact.city}${contact.street}${contact.building}`.trim()
+    if (address) return address
+    if (contact.postalCode.trim()) return `〒${contact.postalCode}`
+    return '住所未設定'
+  }
   const displayContacts = showPrintTargetOnly
     ? contacts.filter((c) => c.isPrintTarget)
     : contacts
@@ -115,12 +128,29 @@ export default function ContactList() {
     sent: false,
     received: false,
     mourning: false,
-    createdAt: '',
-    updatedAt: '',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
   })
 
   const getAnnualStatus = (contactID: string): ContactYearStatus =>
     annualStatuses[contactID] ?? getDefaultAnnualStatus(contactID)
+
+  const buildAnnualStatusPayload = (
+    contactID: string,
+    patch: Partial<Pick<ContactYearStatus, AnnualStatusField>>,
+    requestYear: number,
+  ): Parameters<typeof SaveContactYearStatus>[0] => {
+    const current = getAnnualStatus(contactID)
+    const now = new Date().toISOString()
+    const createdAt = current.createdAt?.trim() ? current.createdAt : now
+    return {
+      ...current,
+      ...patch,
+      year: requestYear,
+      createdAt,
+      updatedAt: now,
+    } as Parameters<typeof SaveContactYearStatus>[0]
+  }
 
   const refreshGroups = () => {
     GetGroups().then(setGroups).catch(console.error)
@@ -356,11 +386,9 @@ export default function ContactList() {
     })
     try {
       const current = getAnnualStatus(contactID)
-      const saved = await SaveContactYearStatus({
-        ...current,
-        [field]: !current[field],
-        year: requestYear,
-      } as Parameters<typeof SaveContactYearStatus>[0])
+      const saved = await SaveContactYearStatus(
+        buildAnnualStatusPayload(contactID, { [field]: !current[field] }, requestYear),
+      )
       if (useContactStore.getState().annualStatusYear === requestYear) {
         upsertAnnualStatuses([saved])
       }
@@ -383,14 +411,9 @@ export default function ContactList() {
     setBulkUpdatingAnnualStatus(true)
     try {
       const results = await Promise.allSettled(
-        selectedVisibleContacts.map((contact) => {
-          const current = getAnnualStatus(contact.id)
-          return SaveContactYearStatus({
-            ...current,
-            ...patch,
-            year: requestYear,
-          } as Parameters<typeof SaveContactYearStatus>[0])
-        }),
+        selectedVisibleContacts.map((contact) =>
+          SaveContactYearStatus(buildAnnualStatusPayload(contact.id, patch, requestYear)),
+        ),
       )
       const savedList = results.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : []))
       const failed = results.filter((result) => result.status === 'rejected')
@@ -812,6 +835,7 @@ export default function ContactList() {
             <thead className="sticky top-0 z-10 bg-gray-50 text-xs text-gray-500">
               <tr>
                 <th className="w-10 px-2 py-2 border-b border-gray-200 text-left">選択</th>
+                <th className="min-w-[220px] px-2 py-2 border-b border-gray-200 text-left font-medium">宛先</th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">印刷対象</th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">{annualStatusYear}送付</th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">{annualStatusYear}受取</th>
@@ -857,6 +881,12 @@ export default function ContactList() {
                         onClick={(e) => e.stopPropagation()}
                         className="mt-1 h-3.5 w-3.5 accent-blue-600"
                       />
+                    </td>
+                    <td className="px-2 py-1.5 border-b border-gray-100 align-top">
+                      <div className="min-w-[220px] max-w-[300px]">
+                        <p className="truncate text-sm font-medium text-gray-800">{getDisplayName(c)}</p>
+                        <p className="truncate text-xs text-gray-500">{getDisplayAddress(c)}</p>
+                      </div>
                     </td>
                     <td className="px-2 py-1.5 border-b border-gray-100 align-top">
                       <input

--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   GetContacts,
   GetGroups,
@@ -34,22 +34,37 @@ interface CellTarget {
   field: EditableField
 }
 
+interface ColumnResizeState {
+  key: string
+  minWidth: number
+  startX: number
+  startWidth: number
+}
+
 const editableColumns: Array<{
   field: EditableField
   label: string
-  widthClass: string
+  defaultWidth: number
+  minWidth: number
   placeholder?: string
 }> = [
-  { field: 'familyName', label: '姓', widthClass: 'min-w-[100px]', placeholder: '姓' },
-  { field: 'givenName', label: '名', widthClass: 'min-w-[100px]', placeholder: '名' },
-  { field: 'honorific', label: '敬称', widthClass: 'min-w-[90px]', placeholder: '様' },
-  { field: 'postalCode', label: '郵便番号', widthClass: 'min-w-[120px]', placeholder: '1000001' },
-  { field: 'prefecture', label: '都道府県', widthClass: 'min-w-[120px]', placeholder: '東京都' },
-  { field: 'city', label: '市区町村', widthClass: 'min-w-[130px]', placeholder: '千代田区' },
-  { field: 'street', label: '番地', widthClass: 'min-w-[160px]', placeholder: '1-1-1' },
+  { field: 'familyName', label: '姓', defaultWidth: 110, minWidth: 100, placeholder: '姓' },
+  { field: 'givenName', label: '名', defaultWidth: 110, minWidth: 100, placeholder: '名' },
+  { field: 'honorific', label: '敬称', defaultWidth: 96, minWidth: 90, placeholder: '様' },
+  { field: 'postalCode', label: '郵便番号', defaultWidth: 130, minWidth: 120, placeholder: '1000001' },
+  { field: 'prefecture', label: '都道府県', defaultWidth: 130, minWidth: 120, placeholder: '東京都' },
+  { field: 'city', label: '市区町村', defaultWidth: 140, minWidth: 130, placeholder: '千代田区' },
+  { field: 'street', label: '番地', defaultWidth: 180, minWidth: 160, placeholder: '1-1-1' },
 ]
 
 export default function ContactList() {
+  const summaryColumnKey = 'summary'
+  const detailColumnKey = 'detail'
+  const defaultSummaryColumnWidth = 260
+  const minSummaryColumnWidth = 220
+  const defaultDetailColumnWidth = 80
+  const minDetailColumnWidth = 64
+
   const {
     contacts,
     selectedIds,
@@ -88,11 +103,23 @@ export default function ContactList() {
   const [updatingPrintTargetIds, setUpdatingPrintTargetIds] = useState<Set<string>>(new Set())
   const [bulkUpdatingAnnualStatus, setBulkUpdatingAnnualStatus] = useState(false)
   const [updatingAnnualStatusKeys, setUpdatingAnnualStatusKeys] = useState<Set<string>>(new Set())
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => {
+    const widths: Record<string, number> = {
+      [summaryColumnKey]: defaultSummaryColumnWidth,
+      [detailColumnKey]: defaultDetailColumnWidth,
+    }
+    editableColumns.forEach((col) => {
+      widths[col.field] = col.defaultWidth
+    })
+    return widths
+  })
+  const [resizingColumnKey, setResizingColumnKey] = useState<string | null>(null)
 
   const requestIdRef = useRef(0)
   const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map())
   const editingCellRef = useRef<EditingCell | null>(null)
   const committingRef = useRef(false)
+  const resizingRef = useRef<ColumnResizeState | null>(null)
   const skipBlurRef = useRef(false)
   const skipBlurResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [focusedRowId, setFocusedRowID] = useState<string | null>(null)
@@ -217,6 +244,32 @@ export default function ContactList() {
       if (skipBlurResetTimerRef.current) {
         clearTimeout(skipBlurResetTimerRef.current)
       }
+    }
+  }, [])
+
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent) => {
+      const resizing = resizingRef.current
+      if (!resizing) return
+      const nextWidth = Math.max(resizing.minWidth, resizing.startWidth + (event.clientX - resizing.startX))
+      setColumnWidths((prev) => {
+        if (prev[resizing.key] === nextWidth) return prev
+        return { ...prev, [resizing.key]: nextWidth }
+      })
+    }
+    const handlePointerUp = () => {
+      resizingRef.current = null
+      setResizingColumnKey(null)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
     }
   }, [])
 
@@ -649,6 +702,34 @@ export default function ContactList() {
     )
   }
 
+  const startColumnResize = (key: string, minWidth: number, event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    resizingRef.current = {
+      key,
+      minWidth,
+      startX: event.clientX,
+      startWidth: columnWidths[key] ?? minWidth,
+    }
+    setResizingColumnKey(key)
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }
+
+  const renderResizeHandle = (key: string, minWidth: number) => (
+    <button
+      type="button"
+      onMouseDown={(e) => startColumnResize(key, minWidth, e)}
+      className={`absolute right-0 top-0 z-20 h-full w-3 cursor-col-resize touch-none ${
+        resizingColumnKey === key ? 'bg-blue-200' : 'hover:bg-blue-100'
+      }`}
+      aria-label="列幅を調整"
+      title="ドラッグして列幅を変更"
+    >
+      <span className="mx-auto block h-full w-px bg-gray-300" />
+    </button>
+  )
+
   const tabs = [{ id: '', name: 'すべて' }, ...groups]
   const currentYear = new Date().getFullYear()
   const minYear = currentYear - 10
@@ -831,11 +912,20 @@ export default function ContactList() {
           </div>
         )}
         {!loading && displayContacts.length > 0 && (
-          <table className="w-full min-w-[1220px] border-separate border-spacing-0">
+          <table className="w-full min-w-[1220px] table-fixed border-separate border-spacing-0">
             <thead className="sticky top-0 z-10 bg-gray-50 text-xs text-gray-500">
               <tr>
                 <th className="w-10 px-2 py-2 border-b border-gray-200 text-left">選択</th>
-                <th className="min-w-[220px] px-2 py-2 border-b border-gray-200 text-left font-medium">宛先</th>
+                <th
+                  className="relative px-2 py-2 border-b border-gray-200 text-left font-medium select-none"
+                  style={{
+                    width: columnWidths[summaryColumnKey],
+                    minWidth: minSummaryColumnWidth,
+                  }}
+                >
+                  宛先
+                  {renderResizeHandle(summaryColumnKey, minSummaryColumnWidth)}
+                </th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">印刷対象</th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">{annualStatusYear}送付</th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">{annualStatusYear}受取</th>
@@ -843,12 +933,26 @@ export default function ContactList() {
                 {editableColumns.map((col) => (
                   <th
                     key={col.field}
-                    className={`${col.widthClass} px-2 py-2 border-b border-gray-200 text-left font-medium`}
+                    className="relative px-2 py-2 border-b border-gray-200 text-left font-medium select-none"
+                    style={{
+                      width: columnWidths[col.field],
+                      minWidth: col.minWidth,
+                    }}
                   >
                     {col.label}
+                    {renderResizeHandle(col.field, col.minWidth)}
                   </th>
                 ))}
-                <th className="w-16 px-2 py-2 border-b border-gray-200 text-left font-medium">詳細</th>
+                <th
+                  className="relative px-2 py-2 border-b border-gray-200 text-left font-medium select-none"
+                  style={{
+                    width: columnWidths[detailColumnKey],
+                    minWidth: minDetailColumnWidth,
+                  }}
+                >
+                  詳細
+                  {renderResizeHandle(detailColumnKey, minDetailColumnWidth)}
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -883,7 +987,12 @@ export default function ContactList() {
                       />
                     </td>
                     <td className="px-2 py-1.5 border-b border-gray-100 align-top">
-                      <div className="min-w-[220px] max-w-[300px]">
+                      <div
+                        style={{
+                          width: columnWidths[summaryColumnKey],
+                          minWidth: minSummaryColumnWidth,
+                        }}
+                      >
                         <p className="truncate text-sm font-medium text-gray-800">{getDisplayName(c)}</p>
                         <p className="truncate text-xs text-gray-500">{getDisplayAddress(c)}</p>
                       </div>
@@ -929,11 +1038,24 @@ export default function ContactList() {
                       />
                     </td>
                     {editableColumns.map((col) => (
-                      <td key={col.field} className="px-2 py-1.5 border-b border-gray-100 align-top">
+                      <td
+                        key={col.field}
+                        className="px-2 py-1.5 border-b border-gray-100 align-top"
+                        style={{
+                          width: columnWidths[col.field],
+                          minWidth: col.minWidth,
+                        }}
+                      >
                         {renderEditableCell(c, col.field, col.placeholder)}
                       </td>
                     ))}
-                    <td className="px-2 py-1.5 border-b border-gray-100 align-top">
+                    <td
+                      className="px-2 py-1.5 border-b border-gray-100 align-top"
+                      style={{
+                        width: columnWidths[detailColumnKey],
+                        minWidth: minDetailColumnWidth,
+                      }}
+                    >
                       <button
                         onClick={() => setEditTarget(c)}
                         className="rounded px-2 py-1 text-xs text-gray-500 hover:bg-gray-200 hover:text-gray-700"

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -4,9 +4,11 @@ import {entity} from '../models';
 
 export function AddContactToGroup(arg1:string,arg2:string):Promise<void>;
 
-export function AnalyzeCSVImport(arg1:string,arg2:{[key: string]: number}):Promise<any>;
+export function AnalyzeCSVImport(arg1:string,arg2:Record<string, number>):Promise<entity.CSVImportAnalysis>;
 
-export function ApplyAddressNormalization(arg1:Array<any>):Promise<any>;
+export function ApplyAddressNormalization(arg1:Array<entity.AddressNormalizationSelection>):Promise<entity.AddressNormalizationApplyResult>;
+
+export function CheckUnsupportedCharacters(arg1:entity.PrintJob):Promise<Array<entity.UnsupportedCharacterWarning>>;
 
 export function DeleteContacts(arg1:Array<string>):Promise<void>;
 
@@ -24,13 +26,13 @@ export function GenerateLabelPDF(arg1:entity.PrintJob,arg2:string):Promise<strin
 
 export function GenerateQRPreview(arg1:entity.QRConfig):Promise<Array<number>>;
 
-export function CheckUnsupportedCharacters(arg1:entity.PrintJob):Promise<Array<entity.UnsupportedCharacterWarning>>;
+export function GetAddressNormalizationPreview():Promise<entity.AddressNormalizationPreview>;
 
 export function GetAppVersion():Promise<string>;
 
-export function GetAddressNormalizationPreview():Promise<any>;
+export function GetBackupSettings():Promise<entity.BackupSettings>;
 
-export function GetCSVImportPlan(arg1:string):Promise<any>;
+export function GetCSVImportPlan(arg1:string):Promise<entity.CSVImportPlan>;
 
 export function GetContact(arg1:string):Promise<entity.Contact>;
 
@@ -41,8 +43,6 @@ export function GetContactYearStatuses(arg1:number):Promise<Array<entity.Contact
 export function GetContacts(arg1:string):Promise<Array<entity.Contact>>;
 
 export function GetDashboardStats():Promise<entity.DashboardStats>;
-
-export function GetBackupSettings():Promise<any>;
 
 export function GetGroups():Promise<Array<entity.Group>>;
 
@@ -56,13 +56,13 @@ export function GetWatermarkPresets():Promise<Array<entity.Watermark>>;
 
 export function ImportCSV(arg1:string):Promise<entity.ImportResult>;
 
-export function ImportCSVWithOptions(arg1:string,arg2:{[key: string]: number},arg3:Array<any>):Promise<any>;
+export function ImportCSVWithOptions(arg1:string,arg2:Record<string, number>,arg3:Array<entity.CSVDuplicateResolution>):Promise<entity.CSVImportExecutionResult>;
 
 export function ImportDB():Promise<boolean>;
 
-export function LookupPostal(arg1:string):Promise<entity.Address>;
+export function ListBackupGenerations():Promise<Array<entity.BackupGeneration>>;
 
-export function ListBackupGenerations():Promise<any>;
+export function LookupPostal(arg1:string):Promise<entity.Address>;
 
 export function MarkContactsSentForYear(arg1:Array<string>,arg2:number):Promise<void>;
 
@@ -72,11 +72,11 @@ export function PrintPDF(arg1:string):Promise<void>;
 
 export function RemoveContactFromGroup(arg1:string,arg2:string):Promise<void>;
 
-export function RollbackAddressNormalization(arg1:string):Promise<any>;
+export function RestoreBackupGeneration(arg1:string):Promise<entity.RestoreBackupResult>;
 
-export function RestoreBackupGeneration(arg1:string):Promise<any>;
+export function RollbackAddressNormalization(arg1:string):Promise<entity.AddressNormalizationRollbackResult>;
 
-export function SaveBackupSettings(arg1:any):Promise<any>;
+export function SaveBackupSettings(arg1:entity.BackupSettings):Promise<entity.BackupSettings>;
 
 export function SaveCSVFileDialog(arg1:string):Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -14,6 +14,10 @@ export function ApplyAddressNormalization(arg1) {
   return window['go']['main']['App']['ApplyAddressNormalization'](arg1);
 }
 
+export function CheckUnsupportedCharacters(arg1) {
+  return window['go']['main']['App']['CheckUnsupportedCharacters'](arg1);
+}
+
 export function DeleteContacts(arg1) {
   return window['go']['main']['App']['DeleteContacts'](arg1);
 }
@@ -46,16 +50,16 @@ export function GenerateQRPreview(arg1) {
   return window['go']['main']['App']['GenerateQRPreview'](arg1);
 }
 
-export function CheckUnsupportedCharacters(arg1) {
-  return window['go']['main']['App']['CheckUnsupportedCharacters'](arg1);
+export function GetAddressNormalizationPreview() {
+  return window['go']['main']['App']['GetAddressNormalizationPreview']();
 }
 
 export function GetAppVersion() {
   return window['go']['main']['App']['GetAppVersion']();
 }
 
-export function GetAddressNormalizationPreview() {
-  return window['go']['main']['App']['GetAddressNormalizationPreview']();
+export function GetBackupSettings() {
+  return window['go']['main']['App']['GetBackupSettings']();
 }
 
 export function GetCSVImportPlan(arg1) {
@@ -80,10 +84,6 @@ export function GetContacts(arg1) {
 
 export function GetDashboardStats() {
   return window['go']['main']['App']['GetDashboardStats']();
-}
-
-export function GetBackupSettings() {
-  return window['go']['main']['App']['GetBackupSettings']();
 }
 
 export function GetGroups() {
@@ -118,12 +118,12 @@ export function ImportDB() {
   return window['go']['main']['App']['ImportDB']();
 }
 
-export function LookupPostal(arg1) {
-  return window['go']['main']['App']['LookupPostal'](arg1);
-}
-
 export function ListBackupGenerations() {
   return window['go']['main']['App']['ListBackupGenerations']();
+}
+
+export function LookupPostal(arg1) {
+  return window['go']['main']['App']['LookupPostal'](arg1);
 }
 
 export function MarkContactsSentForYear(arg1, arg2) {
@@ -142,12 +142,12 @@ export function RemoveContactFromGroup(arg1, arg2) {
   return window['go']['main']['App']['RemoveContactFromGroup'](arg1, arg2);
 }
 
-export function RollbackAddressNormalization(arg1) {
-  return window['go']['main']['App']['RollbackAddressNormalization'](arg1);
-}
-
 export function RestoreBackupGeneration(arg1) {
   return window['go']['main']['App']['RestoreBackupGeneration'](arg1);
+}
+
+export function RollbackAddressNormalization(arg1) {
+  return window['go']['main']['App']['RollbackAddressNormalization'](arg1);
 }
 
 export function SaveBackupSettings(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -16,6 +16,426 @@ export namespace entity {
 	        this.town = source["town"];
 	    }
 	}
+	export class AddressNormalizationAddress {
+	    prefecture: string;
+	    city: string;
+	    street: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new AddressNormalizationAddress(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.prefecture = source["prefecture"];
+	        this.city = source["city"];
+	        this.street = source["street"];
+	    }
+	}
+	export class AddressNormalizationApplyResult {
+	    batchId?: string;
+	    appliedCount: number;
+	    skippedCount: number;
+	    failedCount: number;
+	    errors: string[];
+	    canRollback: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new AddressNormalizationApplyResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.batchId = source["batchId"];
+	        this.appliedCount = source["appliedCount"];
+	        this.skippedCount = source["skippedCount"];
+	        this.failedCount = source["failedCount"];
+	        this.errors = source["errors"];
+	        this.canRollback = source["canRollback"];
+	    }
+	}
+	export class AddressNormalizationDiff {
+	    field: string;
+	    before: string;
+	    after: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new AddressNormalizationDiff(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.field = source["field"];
+	        this.before = source["before"];
+	        this.after = source["after"];
+	    }
+	}
+	export class AddressNormalizationCandidate {
+	    contactId: string;
+	    displayName: string;
+	    postalCode: string;
+	    before: AddressNormalizationAddress;
+	    after: AddressNormalizationAddress;
+	    diffs: AddressNormalizationDiff[];
+	
+	    static createFrom(source: any = {}) {
+	        return new AddressNormalizationCandidate(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.contactId = source["contactId"];
+	        this.displayName = source["displayName"];
+	        this.postalCode = source["postalCode"];
+	        this.before = this.convertValues(source["before"], AddressNormalizationAddress);
+	        this.after = this.convertValues(source["after"], AddressNormalizationAddress);
+	        this.diffs = this.convertValues(source["diffs"], AddressNormalizationDiff);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
+	export class AddressNormalizationPreview {
+	    totalContacts: number;
+	    convertibleCount: number;
+	    candidates: AddressNormalizationCandidate[];
+	    canRollback: boolean;
+	    rollbackBatchId?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new AddressNormalizationPreview(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.totalContacts = source["totalContacts"];
+	        this.convertibleCount = source["convertibleCount"];
+	        this.candidates = this.convertValues(source["candidates"], AddressNormalizationCandidate);
+	        this.canRollback = source["canRollback"];
+	        this.rollbackBatchId = source["rollbackBatchId"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class AddressNormalizationRollbackResult {
+	    batchId?: string;
+	    restoredCount: number;
+	    failedCount: number;
+	    errors: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new AddressNormalizationRollbackResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.batchId = source["batchId"];
+	        this.restoredCount = source["restoredCount"];
+	        this.failedCount = source["failedCount"];
+	        this.errors = source["errors"];
+	    }
+	}
+	export class AddressNormalizationSelection {
+	    contactId: string;
+	    apply: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new AddressNormalizationSelection(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.contactId = source["contactId"];
+	        this.apply = source["apply"];
+	    }
+	}
+	export class BackupGeneration {
+	    id: string;
+	    createdAt: string;
+	    contactCount: number;
+	    trigger: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new BackupGeneration(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.createdAt = source["createdAt"];
+	        this.contactCount = source["contactCount"];
+	        this.trigger = source["trigger"];
+	    }
+	}
+	export class BackupTimingSettings {
+	    onStartup: boolean;
+	    onShutdown: boolean;
+	    intervalMinutes: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new BackupTimingSettings(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.onStartup = source["onStartup"];
+	        this.onShutdown = source["onShutdown"];
+	        this.intervalMinutes = source["intervalMinutes"];
+	    }
+	}
+	export class BackupSettings {
+	    timing: BackupTimingSettings;
+	    maxGenerations: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new BackupSettings(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.timing = this.convertValues(source["timing"], BackupTimingSettings);
+	        this.maxGenerations = source["maxGenerations"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
+	export class CSVContactSnapshot {
+	    id?: string;
+	    displayName: string;
+	    postalCode: string;
+	    prefecture: string;
+	    city: string;
+	    street: string;
+	    company: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new CSVContactSnapshot(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.displayName = source["displayName"];
+	        this.postalCode = source["postalCode"];
+	        this.prefecture = source["prefecture"];
+	        this.city = source["city"];
+	        this.street = source["street"];
+	        this.company = source["company"];
+	    }
+	}
+	export class CSVDuplicateCandidate {
+	    rowNumber: number;
+	    incoming: CSVContactSnapshot;
+	    existing: CSVContactSnapshot;
+	    suggestedAction: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new CSVDuplicateCandidate(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.rowNumber = source["rowNumber"];
+	        this.incoming = this.convertValues(source["incoming"], CSVContactSnapshot);
+	        this.existing = this.convertValues(source["existing"], CSVContactSnapshot);
+	        this.suggestedAction = source["suggestedAction"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class CSVDuplicateResolution {
+	    rowNumber: number;
+	    action: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new CSVDuplicateResolution(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.rowNumber = source["rowNumber"];
+	        this.action = source["action"];
+	    }
+	}
+	export class CSVImportAnalysis {
+	    duplicateRule: string;
+	    validRowCount: number;
+	    errors: string[];
+	    duplicates: CSVDuplicateCandidate[];
+	
+	    static createFrom(source: any = {}) {
+	        return new CSVImportAnalysis(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.duplicateRule = source["duplicateRule"];
+	        this.validRowCount = source["validRowCount"];
+	        this.errors = source["errors"];
+	        this.duplicates = this.convertValues(source["duplicates"], CSVDuplicateCandidate);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class CSVImportExecutionResult {
+	    totalRows: number;
+	    created: number;
+	    updated: number;
+	    skipped: number;
+	    duplicateResolved: number;
+	    errors: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new CSVImportExecutionResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.totalRows = source["totalRows"];
+	        this.created = source["created"];
+	        this.updated = source["updated"];
+	        this.skipped = source["skipped"];
+	        this.duplicateResolved = source["duplicateResolved"];
+	        this.errors = source["errors"];
+	    }
+	}
+	export class CSVImportField {
+	    key: string;
+	    label: string;
+	    required: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new CSVImportField(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.key = source["key"];
+	        this.label = source["label"];
+	        this.required = source["required"];
+	    }
+	}
+	export class CSVImportPlan {
+	    headers: string[];
+	    sampleRows: string[][];
+	    suggestedMapping: Record<string, number>;
+	    fieldDefinitions: CSVImportField[];
+	    rowCount: number;
+	    duplicateRule: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new CSVImportPlan(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.headers = source["headers"];
+	        this.sampleRows = source["sampleRows"];
+	        this.suggestedMapping = source["suggestedMapping"];
+	        this.fieldDefinitions = this.convertValues(source["fieldDefinitions"], CSVImportField);
+	        this.rowCount = source["rowCount"];
+	        this.duplicateRule = source["duplicateRule"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class Contact {
 	    id: string;
 	    familyName: string;
@@ -421,24 +841,25 @@ export namespace entity {
 		    return a;
 		}
 	}
-
-	export class UnsupportedCharacterWarning {
-	    contactId: string;
-	    contactName: string;
-	    characters: string[];
-
+	
+	export class RestoreBackupResult {
+	    restored: boolean;
+	    backupId: string;
+	    preservedBackupId: string;
+	    restartRequired: boolean;
+	
 	    static createFrom(source: any = {}) {
-	        return new UnsupportedCharacterWarning(source);
+	        return new RestoreBackupResult(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.contactId = source["contactId"];
-	        this.contactName = source["contactName"];
-	        this.characters = source["characters"];
+	        this.restored = source["restored"];
+	        this.backupId = source["backupId"];
+	        this.preservedBackupId = source["preservedBackupId"];
+	        this.restartRequired = source["restartRequired"];
 	    }
 	}
-	
 	export class Sender {
 	    id: string;
 	    familyName: string;
@@ -471,5 +892,22 @@ export namespace entity {
 	}
 	
 	
+	export class UnsupportedCharacterWarning {
+	    contactId: string;
+	    contactName: string;
+	    characters: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new UnsupportedCharacterWarning(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.contactId = source["contactId"];
+	        this.contactName = source["contactName"];
+	        this.characters = source["characters"];
+	    }
+	}
 
 }
+

--- a/internal/entity/backup.go
+++ b/internal/entity/backup.go
@@ -17,10 +17,10 @@ type BackupSettings struct {
 
 // BackupGeneration is one restorable backup snapshot.
 type BackupGeneration struct {
-	ID           string    `json:"id"`
-	CreatedAt    time.Time `json:"createdAt"`
-	ContactCount int       `json:"contactCount"`
-	Trigger      string    `json:"trigger"`
+	ID           string `json:"id"`
+	CreatedAt    string `json:"createdAt"`
+	ContactCount int    `json:"contactCount"`
+	Trigger      string `json:"trigger"`
 }
 
 // BackupGenerationRecord stores generation metadata with backing file info.

--- a/internal/usecase/backup_usecase.go
+++ b/internal/usecase/backup_usecase.go
@@ -122,18 +122,19 @@ func (uc *BackupUseCase) ListGenerations() ([]entity.BackupGeneration, error) {
 			return nil, fmt.Errorf("save cleaned generations: %w", err)
 		}
 	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].CreatedAt.After(filtered[j].CreatedAt)
+	})
+
 	out := make([]entity.BackupGeneration, 0, len(filtered))
 	for _, record := range filtered {
 		out = append(out, entity.BackupGeneration{
 			ID:           record.ID,
-			CreatedAt:    record.CreatedAt,
+			CreatedAt:    record.CreatedAt.Format(time.RFC3339Nano),
 			ContactCount: record.ContactCount,
 			Trigger:      record.Trigger,
 		})
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].CreatedAt.After(out[j].CreatedAt)
-	})
 	return out, nil
 }
 
@@ -244,7 +245,7 @@ func (uc *BackupUseCase) runManagedBackup(ctx context.Context, trigger string) (
 	}
 	return entity.BackupGeneration{
 		ID:           backupID,
-		CreatedAt:    now,
+		CreatedAt:    now.Format(time.RFC3339Nano),
 		ContactCount: contactCount,
 		Trigger:      trigger,
 	}, nil


### PR DESCRIPTION
## 概要
- 住所録一覧で宛先情報が判別しづらい問題に対応
- 住所録パネル（中央列）の幅をドラッグで調整可能に変更
- 住所録テーブル内の列幅をヘッダー境界のドラッグで調整可能に変更

## 変更内容
- `ContactList` に宛先サマリ列（氏名 + 住所）を追加
- `ContactList` の各編集列にリサイズハンドルを追加
- `App` で住所録パネル右端のリサイズハンドルを追加

## 動作確認
- `npm --prefix frontend run build`
- `npm --prefix frontend run test:run`

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コンタクトパネルがリサイズ可能になりました。パネルの端をドラッグして幅を調整できます。
  * コンタクトリスト内の列がリサイズ可能になりました。列ヘッダー間のディバイダーをドラッグして列幅をカスタマイズできます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->