### PR TITLE
[#82] ラベルプレビューUIの視覚整理 (Phase 1)

### DIFF
--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -9,6 +9,7 @@ import LabelEditorOverlay from './LabelEditorOverlay'
 import LabelGridOverlay from './LabelGridOverlay'
 import WatermarkLayer from './WatermarkLayer'
 import QROverlay from './QROverlay'
+import { Popover } from '../ui/popover'
 import { useLabelStore } from '../../stores/labelStore'
 import type { Contact, Template, Watermark, QRConfig } from '../../types'
 import {
@@ -162,7 +163,6 @@ export default function PreviewArea() {
 
   const zoomIn = () => setZoom(clampZoom(Math.round((zoom + ZOOM_STEP) * 100) / 100))
   const zoomOut = () => setZoom(clampZoom(Math.round((zoom - ZOOM_STEP) * 100) / 100))
-  const zoomReset = () => setZoom(1)
 
   // 要素配置変更ハンドラ
   function handleTemplateChange(updated: Template) {
@@ -393,7 +393,7 @@ export default function PreviewArea() {
   }, [currentContact, selectedFieldId])
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden bg-[#f0f0f0]">
+    <div className="flex-1 flex flex-col overflow-hidden bg-slate-200">
       {/* ツールバー */}
       <div className="bg-white border-b border-gray-200 shrink-0">
         <div className="flex items-center gap-3 px-4 py-2">
@@ -437,40 +437,48 @@ export default function PreviewArea() {
             <button
               onClick={zoomOut}
               disabled={zoom <= ZOOM_MIN}
-              className="px-2 py-1 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
+              className="h-8 w-8 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
               aria-label="ズームアウト"
             >
               −
             </button>
-            <button
-              onClick={zoomReset}
-              className="px-3 py-1 text-xs rounded border border-gray-300 hover:bg-gray-100 min-w-[52px] text-center"
+            <Popover
+              triggerLabel={`${currentZoomPct}%`}
+              triggerClassName="h-8 px-3 text-xs rounded border border-gray-300 bg-white hover:bg-gray-100 min-w-[64px] text-center"
+              triggerTitle="表示倍率を選択"
+              align="right"
             >
-              {currentZoomPct}%
-            </button>
+              {(close) => (
+                <div className="flex flex-col py-1 min-w-[88px]">
+                  {zoomOptions.map((pct) => {
+                    const isCurrent = pct === currentZoomPct
+                    return (
+                      <button
+                        key={pct}
+                        type="button"
+                        onClick={() => {
+                          setZoom(clampZoom(pct / 100))
+                          close()
+                        }}
+                        className={`px-3 py-1 text-xs text-right hover:bg-gray-100 ${
+                          isCurrent ? 'text-blue-600 font-medium' : 'text-gray-700'
+                        }`}
+                      >
+                        {pct}%
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </Popover>
             <button
               onClick={zoomIn}
               disabled={zoom >= ZOOM_MAX}
-              className="px-2 py-1 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
+              className="h-8 w-8 text-sm rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-40"
               aria-label="ズームイン"
             >
               ＋
             </button>
-            <select
-              value={currentZoomPct}
-              onChange={(e) => {
-                const next = Number.parseInt(e.target.value, 10)
-                if (Number.isFinite(next)) setZoom(clampZoom(next / 100))
-              }}
-              className="h-8 rounded border border-gray-300 bg-white px-2 text-xs text-gray-700"
-              title="表示倍率"
-            >
-              {zoomOptions.map((pct) => (
-                <option key={pct} value={pct}>
-                  {pct}%
-                </option>
-              ))}
-            </select>
           </div>
         </div>
 
@@ -496,7 +504,9 @@ export default function PreviewArea() {
                   title={`${box.label} を編集`}
                 >
                   <span
-                    className="inline-block h-2 w-2 rounded-full"
+                    className={`inline-block h-2.5 w-2.5 rounded-full ${
+                      selected ? 'ring-2 ring-white ring-offset-0' : ''
+                    }`}
                     style={{ backgroundColor: box.color }}
                   />
                   {box.label}
@@ -650,15 +660,26 @@ export default function PreviewArea() {
             太字
           </button>
 
-          <span className="text-[11px] text-gray-500">
-            矢印キーで 0.1mm、Shift+矢印で 1.0mm 移動。ドラッグと数値は同期。
-          </span>
-          <span className="text-[11px] text-gray-500">
-            内容入力は即時プレビュー反映。確定で保存、キャンセルで破棄。
-          </span>
-          {!contentSaving && !hasContentDraft && (
-            <span className="text-[11px] text-gray-500">変更すると「確定」が有効になります。</span>
-          )}
+          <Popover
+            triggerLabel="?"
+            triggerClassName="ml-auto h-7 w-7 rounded-full border border-gray-300 bg-white text-xs text-gray-500 hover:bg-gray-100"
+            triggerTitle="操作ヘルプを表示"
+            triggerAriaLabel="操作ヘルプを表示"
+            align="right"
+          >
+            {() => (
+              <div className="w-72 p-3 text-xs text-gray-600 space-y-2">
+                <p>
+                  <span className="font-medium text-gray-700">移動: </span>
+                  矢印キーで 0.1mm、Shift+矢印で 1.0mm 移動。ドラッグと数値は同期。
+                </p>
+                <p>
+                  <span className="font-medium text-gray-700">内容編集: </span>
+                  入力は即時プレビュー反映。「確定」で保存、「キャンセル」で破棄。
+                </p>
+              </div>
+            )}
+          </Popover>
           {contentError && (
             <span className="text-[11px] text-red-600">{contentError}</span>
           )}
@@ -757,7 +778,7 @@ interface LabelStackProps {
 
 function LabelStack({ contact, template, zoom, watermark, qrConfig }: LabelStackProps) {
   return (
-    <div className="relative shadow-md" style={{ display: 'inline-block' }}>
+    <div className="relative shadow-lg ring-1 ring-black/5" style={{ display: 'inline-block' }}>
       <LabelCanvas contact={contact} template={template} zoom={zoom} />
       <WatermarkLayer
         watermark={watermark}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+interface PopoverProps {
+  triggerLabel: ReactNode
+  triggerClassName?: string
+  triggerTitle?: string
+  triggerAriaLabel?: string
+  align?: 'left' | 'right'
+  children: (close: () => void) => ReactNode
+}
+
+export function Popover({
+  triggerLabel,
+  triggerClassName,
+  triggerTitle,
+  triggerAriaLabel,
+  align = 'right',
+  children,
+}: PopoverProps) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null
+      if (!target) return
+      if (triggerRef.current?.contains(target)) return
+      if (contentRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div className="relative inline-block">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label={triggerAriaLabel}
+        title={triggerTitle}
+        className={triggerClassName}
+      >
+        {triggerLabel}
+      </button>
+      {open && (
+        <div
+          ref={contentRef}
+          role="dialog"
+          className={`absolute top-full mt-1 z-50 rounded-md border border-gray-200 bg-white shadow-lg ${
+            align === 'right' ? 'right-0' : 'left-0'
+          }`}
+        >
+          {children(() => setOpen(false))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- issue #82 のラベルプレビュー画面デザイン見直しのうち、軽量で先行リリース可能な視覚整理を Phase 1 として実装
- ズームUIの重複表示・常時ヘルプ3行・選択ピルの色同化・薄い背景といった「リボンが折り返す/紙が見えない」状態を改善
- 後続 Phase 2 (トップバー再設計) / Phase 3 (編集インスペクタ分離) は別 PR で対応予定

## 変更内容
- ズームコントロールを `−` / `100% (Popover)` / `＋` の3要素に集約 (元: − / リセット / + / select の4要素で同じ値が二重表示)
- 常時表示のヘルプ3行を末尾の `?` Popover に集約してリボンの折り返しを軽減
- 編集対象ピルの選択中ドットに `ring-2 ring-white` を追加し、選択色 (濃紺) との同化を解消
- キャンバス背景 `bg-[#f0f0f0]` → `bg-slate-200`、ラベル本体に `shadow-lg ring-1 ring-black/5` を付与
- 軽量 Popover プリミティブ ([popover.tsx](frontend/src/components/ui/popover.tsx)) を追加 (click-outside / Escape 対応、依存追加なし)

## Test plan
- [x] `wails dev` でラベルプレビューを開き、ズーム% クリックでプリセットが Popover で表示される
- [x] ヘルプ末尾の `?` クリックで操作ヘルプ Popover が開く / Escape / 外クリックで閉じる
- [x] 編集対象ピルで「郵便番号」を選択中、青ドットが白リングで識別できる
- [x] ラベル本体の影と背景コントラストが強くなり、紙感が出ている
- [x] `npx tsc --noEmit` 通過、`npx vitest run` 全テスト pass

Closes (部分対応): #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ズーム選択をポップオーバーUIに移動し、操作性が向上しました。
  * ヘルプテキストがポップオーバーで表示されるようになりました。

* **スタイル**
  * ラベルスタックコンテナの視覚的デザインを改善（シャドウと枠線を追加）。
  * プレビュー領域の背景色を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->