### PR TITLE
[#82] ラベルプレビュートップバー・右パネル再設計 (Phase 2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,9 +9,9 @@ import PrintConfirmDialog from './components/PrintConfirmDialog'
 import SenderManager from './components/sender/SenderManager'
 import Dashboard from './components/Dashboard'
 import Settings from './components/Settings'
-import { useDecorationStore } from './stores/decorationStore'
-import { useLabelStore } from './stores/labelStore'
 import { useContactStore } from './stores/contactStore'
+
+type RightPanel = 'label' | 'design' | null
 
 function App() {
   const minContactPaneWidth = 300
@@ -21,15 +21,14 @@ function App() {
   const [showPrintDialog, setShowPrintDialog] = useState(false)
   const [contactPaneWidth, setContactPaneWidth] = useState(defaultContactPaneWidth)
   const [isResizingContactPane, setIsResizingContactPane] = useState(false)
+  const [rightPanel, setRightPanel] = useState<RightPanel>(null)
 
   const contactPaneResizeRef = useRef<{ startX: number; startWidth: number } | null>(null)
 
-  const { showDecoPanel, toggleDecoPanel } = useDecorationStore(
-    useShallow((s) => ({ showDecoPanel: s.showDecoPanel, toggleDecoPanel: s.toggleDecoPanel })),
-  )
-  const { showPanel: showLabelPanel, togglePanel: toggleLabelPanel } = useLabelStore(
-    useShallow((s) => ({ showPanel: s.showPanel, togglePanel: s.togglePanel })),
-  )
+  const toggleRightPanel = (next: Exclude<RightPanel, null>) => {
+    setRightPanel((prev) => (prev === next ? null : next))
+  }
+
   const {
     selectedCount,
     setSelectedIds,
@@ -151,48 +150,73 @@ function App() {
           <>
             <div className="flex-1 flex flex-col overflow-hidden min-w-0">
               {/* トップバー */}
-              <div className="flex items-center justify-end gap-2 px-4 py-2 bg-white border-b border-gray-200 shrink-0">
-                <button
-                  onClick={toggleLabelPanel}
-                  className={`px-3 py-1.5 text-xs rounded border transition-colors ${
-                    showLabelPanel
-                      ? 'bg-green-50 border-green-400 text-green-700'
-                      : 'border-gray-300 text-gray-600 hover:bg-gray-100'
-                  }`}
-                >
-                  ラベル設定
-                </button>
-                <button
-                  onClick={toggleDecoPanel}
-                  className={`px-3 py-1.5 text-xs rounded border transition-colors ${
-                    showDecoPanel
-                      ? 'bg-blue-50 border-blue-400 text-blue-700'
-                      : 'border-gray-300 text-gray-600 hover:bg-gray-100'
-                  }`}
-                >
-                  デザイン設定
-                </button>
+              <div className="flex items-center gap-2 px-4 py-2 bg-white border-b border-gray-200 shrink-0">
+                <div className="flex items-center gap-1 mr-auto">
+                  <SecondaryToggleButton
+                    active={rightPanel === 'label'}
+                    onClick={() => toggleRightPanel('label')}
+                    icon={<LabelIcon />}
+                    label="ラベル設定"
+                  />
+                  <SecondaryToggleButton
+                    active={rightPanel === 'design'}
+                    onClick={() => toggleRightPanel('design')}
+                    icon={<DesignIcon />}
+                    label="デザイン設定"
+                  />
+                </div>
                 <button
                   onClick={() => setShowPrintDialog(true)}
                   disabled={selectedCount === 0}
-                  className="px-3 py-1.5 text-xs rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40"
+                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-blue-600 text-white shadow-sm hover:bg-blue-700 active:bg-blue-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 >
-                  ラベル印刷 {selectedCount > 0 && `(${selectedCount}件)`}
+                  <PrintIcon />
+                  ラベル印刷
+                  {selectedCount > 0 && (
+                    <span className="ml-0.5 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[11px] font-semibold rounded-full bg-white/20 text-white">
+                      {selectedCount}
+                    </span>
+                  )}
                 </button>
               </div>
               <PreviewArea />
             </div>
-            {showLabelPanel && (
-              <div className="w-60 bg-white border-l border-gray-200 flex flex-col h-full shrink-0">
-                <div className="px-4 py-3 border-b border-gray-200">
-                  <h2 className="text-sm font-semibold text-gray-700">ラベル設定</h2>
+            {rightPanel && (
+              <div className="w-72 bg-white border-l border-gray-200 flex flex-col h-full shrink-0">
+                <div className="flex items-stretch border-b border-gray-200">
+                  <PanelTab
+                    active={rightPanel === 'label'}
+                    onClick={() => setRightPanel('label')}
+                  >
+                    ラベル設定
+                  </PanelTab>
+                  <PanelTab
+                    active={rightPanel === 'design'}
+                    onClick={() => setRightPanel('design')}
+                  >
+                    デザイン設定
+                  </PanelTab>
+                  <button
+                    type="button"
+                    onClick={() => setRightPanel(null)}
+                    className="ml-auto px-3 text-gray-400 hover:text-gray-600"
+                    aria-label="パネルを閉じる"
+                    title="パネルを閉じる"
+                  >
+                    ×
+                  </button>
                 </div>
-                <div className="flex-1 overflow-y-auto p-4">
-                  <LabelSettingsPanel />
+                <div className="flex-1 overflow-y-auto">
+                  {rightPanel === 'label' ? (
+                    <div className="p-4">
+                      <LabelSettingsPanel />
+                    </div>
+                  ) : (
+                    <DecorationSidebar />
+                  )}
                 </div>
               </div>
             )}
-            {showDecoPanel && <DecorationSidebar />}
           </>
         )}
         {view === 'senders' && (
@@ -233,6 +257,120 @@ function NavButton({
     >
       {children}
     </button>
+  )
+}
+
+function SecondaryToggleButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs transition-colors ${
+        active
+          ? 'bg-gray-100 text-gray-800 ring-1 ring-gray-300'
+          : 'text-gray-600 hover:bg-gray-100'
+      }`}
+    >
+      <span className="text-gray-500" aria-hidden="true">
+        {icon}
+      </span>
+      {label}
+    </button>
+  )
+}
+
+function PanelTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`px-4 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+        active
+          ? 'text-blue-700 border-blue-600'
+          : 'text-gray-500 border-transparent hover:text-gray-700 hover:bg-gray-50'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function PrintIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="6 9 6 2 18 2 18 9" />
+      <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+      <rect x="6" y="14" width="12" height="8" />
+    </svg>
+  )
+}
+
+function LabelIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  )
+}
+
+function DesignIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 3v18" />
+      <path d="M3 12h18" />
+    </svg>
   )
 }
 

--- a/frontend/src/components/decoration/DecorationSidebar.tsx
+++ b/frontend/src/components/decoration/DecorationSidebar.tsx
@@ -3,15 +3,10 @@ import QRPanel from './QRPanel'
 
 export default function DecorationSidebar() {
   return (
-    <div className="w-60 bg-white border-l border-gray-200 flex flex-col h-full shrink-0">
-      <div className="px-4 py-3 border-b border-gray-200">
-        <h2 className="text-sm font-semibold text-gray-700">デザイン設定</h2>
-      </div>
-      <div className="flex-1 overflow-y-auto p-4 space-y-6">
-        <WatermarkPanel />
-        <div className="border-t border-gray-100" />
-        <QRPanel />
-      </div>
+    <div className="p-4 space-y-6">
+      <WatermarkPanel />
+      <div className="border-t border-gray-100" />
+      <QRPanel />
     </div>
   )
 }

--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -397,29 +397,34 @@ export default function PreviewArea() {
       {/* ツールバー */}
       <div className="bg-white border-b border-gray-200 shrink-0">
         <div className="flex items-center gap-3 px-4 py-2">
-          <span className="text-sm font-medium text-gray-700 mr-auto">
-            {template.name}
+          <div className="flex items-center gap-2 mr-auto min-w-0">
+            <span className="text-sm font-medium text-gray-700 truncate">
+              {template.name}
+            </span>
             {selectedContacts.length > 0 && (
-              <span className="ml-2 text-xs text-gray-400">
+              <span className="text-xs text-gray-400 shrink-0">
                 {safeIndex + 1} / {selectedContacts.length} 件
               </span>
             )}
-          </span>
-          {/* オフセット表示 */}
-          {currentContact && hasOffset && (
-            <div className="flex items-center gap-1 text-xs text-amber-600">
-              <span>
-                補正: X {displayOffset.x.toFixed(1)} / Y {displayOffset.y.toFixed(1)} mm
+            {/* オフセット表示 (バッジ) */}
+            {currentContact && hasOffset && (
+              <span className="inline-flex items-center gap-1 shrink-0 pl-2 pr-1 py-0.5 rounded-full bg-amber-50 border border-amber-200 text-[11px] text-amber-700">
+                <span aria-hidden="true">⚠</span>
+                <span>
+                  補正 X {displayOffset.x.toFixed(1)} / Y {displayOffset.y.toFixed(1)} mm
+                </span>
+                <button
+                  type="button"
+                  onClick={resetOffset}
+                  className="ml-0.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-amber-600 hover:bg-amber-100 hover:text-amber-800"
+                  title="補正を初期値に戻す"
+                  aria-label="補正をリセット"
+                >
+                  ×
+                </button>
               </span>
-              <button
-                onClick={resetOffset}
-                className="underline hover:text-amber-800"
-                title="補正を初期値に戻す"
-              >
-                リセット
-              </button>
-            </div>
-          )}
+            )}
+          </div>
           {/* グリッドトグル */}
           <button
             onClick={() => setShowGrid((v) => !v)}

--- a/frontend/src/stores/decorationStore.test.ts
+++ b/frontend/src/stores/decorationStore.test.ts
@@ -10,7 +10,7 @@ const defaultQRConfig: QRConfig = {
 }
 
 beforeEach(() => {
-  useDecorationStore.setState({ watermark: null, qrConfig: defaultQRConfig, showDecoPanel: false })
+  useDecorationStore.setState({ watermark: null, qrConfig: defaultQRConfig })
 })
 
 describe('decorationStore', () => {
@@ -47,11 +47,4 @@ describe('decorationStore', () => {
     expect(useDecorationStore.getState().qrConfig.position).toBe('top-left')
   })
 
-  it('toggleDecoPanel: ON/OFFが切り替わる', () => {
-    expect(useDecorationStore.getState().showDecoPanel).toBe(false)
-    useDecorationStore.getState().toggleDecoPanel()
-    expect(useDecorationStore.getState().showDecoPanel).toBe(true)
-    useDecorationStore.getState().toggleDecoPanel()
-    expect(useDecorationStore.getState().showDecoPanel).toBe(false)
-  })
 })

--- a/frontend/src/stores/decorationStore.ts
+++ b/frontend/src/stores/decorationStore.ts
@@ -4,10 +4,8 @@ import type { Watermark, QRConfig } from '../types'
 interface DecorationState {
   watermark: Watermark | null
   qrConfig: QRConfig
-  showDecoPanel: boolean
   setWatermark: (watermark: Watermark | null) => void
   setQRConfig: (config: Partial<QRConfig>) => void
-  toggleDecoPanel: () => void
 }
 
 const defaultQRConfig: QRConfig = {
@@ -20,8 +18,6 @@ const defaultQRConfig: QRConfig = {
 export const useDecorationStore = create<DecorationState>((set, get) => ({
   watermark: null,
   qrConfig: defaultQRConfig,
-  showDecoPanel: false,
   setWatermark: (watermark) => set({ watermark }),
   setQRConfig: (config) => set({ qrConfig: { ...get().qrConfig, ...config } }),
-  toggleDecoPanel: () => set({ showDecoPanel: !get().showDecoPanel }),
 }))

--- a/frontend/src/stores/labelStore.ts
+++ b/frontend/src/stores/labelStore.ts
@@ -21,11 +21,9 @@ interface LabelState {
   layout: LabelLayout
   orientation: 'vertical' | 'horizontal'
   selectedSender: Sender | null
-  showPanel: boolean
   setLayout: (layout: Partial<LabelLayout>) => void
   setOrientation: (orientation: 'vertical' | 'horizontal') => void
   setSelectedSender: (sender: Sender | null) => void
-  togglePanel: () => void
   resetOffset: () => void
 }
 
@@ -35,11 +33,9 @@ export const useLabelStore = create<LabelState>()(
       layout: defaultLayout,
       orientation: 'vertical',
       selectedSender: null,
-      showPanel: false,
       setLayout: (layout) => set({ layout: { ...get().layout, ...layout } }),
       setOrientation: (orientation) => set({ orientation }),
       setSelectedSender: (sender) => set({ selectedSender: sender }),
-      togglePanel: () => set({ showPanel: !get().showPanel }),
       resetOffset: () => set({ layout: { ...get().layout, offsetX: 0, offsetY: 0 } }),
     }),
     {


### PR DESCRIPTION
## Summary
- issue #82 の Phase 2: トップバーの優先度再設計と、右パネルのタブ切替単一スロット化
- Phase 1 (#84) で対応した視覚整理に続き、情報設計レベルの改善を実施

## 変更内容

### トップバー再構成 (App.tsx)
- 「ラベル設定」「デザイン設定」をアイコン+ラベルのセカンダリトグルに格下げし左寄せ
- 「ラベル印刷」を大きめ primary に強化 (プリンタアイコン + 件数バッジ付き)
- 視線が「設定 → 印刷」と左→右に流れる配置に

### 右パネルの単一スロット化
- ラベル設定 / デザイン設定の同時表示を廃止し、タブ切替に統一
- 上部に2タブ + × 閉じるボタン、下にコンテンツ
- 同時表示できないことでキャンバス幅を確保（住所録併設時に有効）

### 状態モデル整理
- `useDecorationStore.showDecoPanel` / `toggleDecoPanel` 削除
- `useLabelStore.showPanel` / `togglePanel` 削除
- App.tsx ローカル state `rightPanel: 'label' | 'design' | null` に集約
- 関連テストも追従

### 補正表示のバッジ化 (PreviewArea.tsx)
- ラベル名と並んでいた amber テキストを角丸バッジ (⚠ + 値 + ×) に変更
- タイトルとの視覚競合を解消し、リセット操作も × アイコンで簡潔に

### DecorationSidebar
- 親コンテナ側で枠を提供するようになったため、外側の幅・ボーダー・見出しを撤去

## Test plan
- [x] `node_modules/.bin/tsc --noEmit` 通過
- [x] `node_modules/.bin/vitest run` 全テスト pass (69/69)
- [x] ラベル印刷ボタンが目立ち、件数バッジが表示される
- [x] ラベル設定 / デザイン設定が同時に開かず、片方クリックで切替
- [x] 同じボタン再クリック / × で閉じる
- [x] 右パネル上部のタブで切替できる
- [x] 補正バッジが視認でき、× で即リセット可能

Closes (部分対応): #82