### PR TITLE
[#82] ラベルプレビュー編集インスペクタの分離 (Phase 3)

### DIFF
--- a/frontend/src/components/preview/LabelEditorOverlay.tsx
+++ b/frontend/src/components/preview/LabelEditorOverlay.tsx
@@ -138,12 +138,14 @@ export default function LabelEditorOverlay({
               top: y,
               width: w,
               height: h,
-              border: `${selected ? 2 : 1.5}px dashed ${box.color}`,
-              background: selected ? `${box.color}20` : 'transparent',
+              border: `${selected ? 2.5 : 1.5}px dashed ${box.color}`,
+              background: selected ? `${box.color}26` : 'transparent',
+              boxShadow: selected ? `0 0 0 3px ${box.color}33` : 'none',
               boxSizing: 'border-box',
               pointerEvents: 'auto',
               cursor: 'move',
               userSelect: 'none',
+              transition: 'box-shadow 120ms ease, background 120ms ease',
               zIndex: selected ? 2 : 1,
             }}
           >

--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -393,7 +393,7 @@ export default function PreviewArea() {
   }, [currentContact, selectedFieldId])
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden bg-slate-200">
+    <div className="relative flex-1 flex flex-col overflow-hidden bg-slate-200">
       {/* ツールバー */}
       <div className="bg-white border-b border-gray-200 shrink-0">
         <div className="flex items-center gap-3 px-4 py-2">
@@ -693,7 +693,7 @@ export default function PreviewArea() {
       </div>
 
       {/* キャンバスエリア */}
-      <div className="relative flex-1 overflow-auto flex items-center justify-center p-6">
+      <div className="flex-1 overflow-auto flex items-center justify-center p-6">
         {mergedCurrentContact ? (
           // オフセット補正を CSS transform で可視化。
           // 背景ドラッグ → 印刷位置補正 / カラーハンドルドラッグ → 要素個別配置
@@ -737,34 +737,6 @@ export default function PreviewArea() {
         ) : (
           <p className="text-gray-400 text-sm">住所録で印刷対象をONにしてください</p>
         )}
-
-        {/* フローティング確定バー (内容ドラフト中のみ) */}
-        {(hasContentDraft || contentSaving) && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center z-20">
-            <div className="pointer-events-auto inline-flex items-center gap-3 px-4 py-2 rounded-full bg-white shadow-lg ring-1 ring-amber-200">
-              <span className="inline-flex items-center gap-1.5 text-xs text-amber-700">
-                <span aria-hidden="true">●</span>
-                内容に未保存の変更があります
-              </span>
-              <button
-                type="button"
-                onClick={cancelEditableContent}
-                disabled={contentSaving}
-                className="h-8 rounded-md border border-gray-300 bg-white px-3 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-40"
-              >
-                キャンセル
-              </button>
-              <button
-                type="button"
-                onClick={() => void saveEditableContent()}
-                disabled={contentSaving}
-                className="h-8 rounded-md bg-blue-600 px-4 text-xs font-medium text-white shadow-sm hover:bg-blue-700 disabled:opacity-70"
-              >
-                {contentSaving ? '保存中...' : '確定'}
-              </button>
-            </div>
-          </div>
-        )}
       </div>
 
       {/* サムネイルナビゲーション (複数選択時) */}
@@ -795,6 +767,38 @@ export default function PreviewArea() {
               </span>
             </button>
           ))}
+        </div>
+      )}
+
+      {/* フローティング確定バー (内容ドラフト中のみ) — overflow-auto の外側に配置してズーム時もビューポートに固定 */}
+      {(hasContentDraft || contentSaving) && (
+        <div
+          className={`pointer-events-none absolute inset-x-0 flex justify-center z-20 ${
+            selectedContacts.length > 1 ? 'bottom-28' : 'bottom-4'
+          }`}
+        >
+          <div className="pointer-events-auto inline-flex items-center gap-3 px-4 py-2 rounded-full bg-white shadow-lg ring-1 ring-amber-200">
+            <span className="inline-flex items-center gap-1.5 text-xs text-amber-700">
+              <span aria-hidden="true">●</span>
+              内容に未保存の変更があります
+            </span>
+            <button
+              type="button"
+              onClick={cancelEditableContent}
+              disabled={contentSaving}
+              className="h-8 rounded-md border border-gray-300 bg-white px-3 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-40"
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              onClick={() => void saveEditableContent()}
+              disabled={contentSaving}
+              className="h-8 rounded-md bg-blue-600 px-4 text-xs font-medium text-white shadow-sm hover:bg-blue-700 disabled:opacity-70"
+            >
+              {contentSaving ? '保存中...' : '確定'}
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -487,183 +487,184 @@ export default function PreviewArea() {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-t border-gray-100 bg-gray-50">
-          <span className="text-xs font-medium text-gray-700">文字設定</span>
-
-          <div className="flex flex-wrap items-center gap-1 rounded border border-gray-300 bg-white p-1">
-            {editableBoxes.length === 0 && (
-              <span className="px-2 text-xs text-gray-500">編集項目なし</span>
-            )}
-            {editableBoxes.map((box) => {
-              const selected = box.id === selectedFieldId
-              return (
-                <button
-                  key={box.id}
-                  onClick={() => setSelectedFieldId(box.id)}
-                  disabled={!currentContact}
-                  className={`h-7 rounded px-2 text-xs border transition-colors inline-flex items-center gap-1.5 ${
-                    selected
-                      ? 'bg-slate-700 text-white border-slate-700'
-                      : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100'
-                  } disabled:opacity-40`}
-                  title={`${box.label} を編集`}
-                >
-                  <span
-                    className={`inline-block h-2.5 w-2.5 rounded-full ${
-                      selected ? 'ring-2 ring-white ring-offset-0' : ''
-                    }`}
-                    style={{ backgroundColor: box.color }}
-                  />
-                  {box.label}
-                </button>
-              )
-            })}
+        <div className="flex flex-wrap items-stretch gap-3 px-4 py-2 border-t border-gray-100 bg-gray-50">
+          {/* Block A: 対象選択 */}
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wide">対象</span>
+            <div className="flex flex-wrap items-center gap-1">
+              {editableBoxes.length === 0 && (
+                <span className="px-2 text-xs text-gray-500">編集項目なし</span>
+              )}
+              {editableBoxes.map((box) => {
+                const selected = box.id === selectedFieldId
+                return (
+                  <button
+                    key={box.id}
+                    onClick={() => setSelectedFieldId(box.id)}
+                    disabled={!currentContact}
+                    className={`h-7 rounded-md px-2 text-xs border transition-colors inline-flex items-center gap-1.5 ${
+                      selected
+                        ? 'bg-slate-700 text-white border-slate-700'
+                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100'
+                    } disabled:opacity-40`}
+                    style={selected ? { boxShadow: `0 0 0 2px ${box.color}55` } : undefined}
+                    title={`${box.label} を編集`}
+                  >
+                    <span
+                      className={`inline-block h-2.5 w-2.5 rounded-full ${
+                        selected ? 'ring-2 ring-white ring-offset-0' : ''
+                      }`}
+                      style={{ backgroundColor: box.color }}
+                    />
+                    {box.label}
+                  </button>
+                )
+              })}
+            </div>
           </div>
 
-          <div className="flex flex-wrap items-center gap-1 rounded border border-gray-300 bg-white p-1">
-            <span className="px-1 text-xs text-gray-500">内容</span>
-            {!currentContact && (
-              <span className="px-1 text-xs text-gray-400">印刷対象を選択してください</span>
-            )}
-            {currentContact && selectedEditableFields.length === 0 && (
-              <span className="px-1 text-xs text-gray-400">編集項目を選択してください</span>
-            )}
-            {currentContact &&
-              selectedEditableFields.map((field) => (
-                <label key={field} className="flex items-center gap-1 pl-1">
-                  <span className="text-[11px] text-gray-500">{EDITABLE_FIELD_LABELS[field]}</span>
-                  <input
-                    type="text"
-                    value={getEditableFieldValue(field)}
-                    onChange={(e) => updateEditableFieldValue(field, e.target.value)}
-                    disabled={contentSaving}
-                    className="h-8 min-w-[86px] rounded border border-gray-300 bg-white px-2 text-xs text-gray-700 disabled:opacity-40"
-                  />
-                </label>
-              ))}
-            <button
-              type="button"
-              onClick={cancelEditableContent}
-              disabled={!hasContentDraft || contentSaving}
-              className="h-8 rounded border border-gray-300 px-2 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-40"
-            >
-              キャンセル
-            </button>
-            <button
-              type="button"
-              onClick={() => void saveEditableContent()}
-              disabled={contentSaving || !hasContentDraft}
-              className={`h-8 rounded border px-2 text-xs transition-colors ${
-                contentSaving
-                  ? 'border-blue-600 bg-blue-600 text-white opacity-70'
-                  : hasContentDraft
-                    ? 'border-blue-600 bg-blue-600 text-white hover:bg-blue-700'
-                    : 'border-gray-300 bg-gray-100 text-gray-500'
-              }`}
-            >
-              {contentSaving ? '保存中...' : hasContentDraft ? '確定' : '保存済み'}
-            </button>
-          </div>
+          <div className="w-px bg-gray-200 self-stretch" aria-hidden="true" />
 
-          <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-500">サイズ</span>
-            <button
-              onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, -0.5))}
-              disabled={!selectedInspector}
-              className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
-              title="文字サイズを小さくする"
-            >
-              −
-            </button>
-            <input
-              type="number"
-              step={0.5}
-              value={selectedInspector ? selectedInspector.fontPt.toFixed(1) : ''}
-              onChange={(e) => updateSelectedFontFromInput(e.target.value)}
-              disabled={!selectedInspector}
-              className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
-              title="フォントサイズ (pt)"
-            />
-            <span className="text-xs text-gray-500">pt</span>
-            <button
-              onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, 0.5))}
-              disabled={!selectedInspector}
-              className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
-              title="文字サイズを大きくする"
-            >
-              ＋
-            </button>
-          </div>
-
-          <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-500">X</span>
-            <input
-              type="number"
-              step={0.1}
-              value={selectedInspector ? selectedInspector.xMm.toFixed(1) : ''}
-              onChange={(e) => updateSelectedPositionFromInput('x', e.target.value)}
-              disabled={!selectedInspector}
-              className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
-              title="X 座標 (mm)"
-            />
-            <span className="text-xs text-gray-500">mm</span>
-          </div>
-
-          <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-500">Y</span>
-            <input
-              type="number"
-              step={0.1}
-              value={selectedInspector ? selectedInspector.yMm.toFixed(1) : ''}
-              onChange={(e) => updateSelectedPositionFromInput('y', e.target.value)}
-              disabled={!selectedInspector}
-              className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
-              title="Y 座標 (mm)"
-            />
-            <span className="text-xs text-gray-500">mm</span>
-          </div>
-
-          <div className="flex items-center rounded border border-gray-300 overflow-hidden">
-            <button
-              onClick={() => updateSelectedField((tpl, id) => applyFontFamily(tpl, id, 'serif'))}
-              disabled={!selectedBox}
-              className={`h-8 px-3 text-xs transition-colors ${
-                selectedBox?.fontFamily === 'serif'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white text-gray-700 hover:bg-gray-100'
-              } disabled:opacity-40`}
-              title="明朝体"
-            >
-              明朝
-            </button>
-            <button
-              onClick={() =>
-                updateSelectedField((tpl, id) => applyFontFamily(tpl, id, 'sans-serif'))
-              }
-              disabled={!selectedBox}
-              className={`h-8 px-3 text-xs border-l border-gray-300 transition-colors ${
-                selectedBox?.fontFamily === 'sans-serif'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white text-gray-700 hover:bg-gray-100'
-              } disabled:opacity-40`}
-              title="ゴシック体"
-            >
-              ゴシック
-            </button>
-          </div>
-
-          <button
-            onClick={() => updateSelectedField((tpl, id) => applyBold(tpl, id, !selectedBox?.bold))}
-            disabled={!selectedBox}
-            className={`h-8 px-3 rounded border text-xs transition-colors ${
-              selectedBox?.bold
-                ? 'bg-slate-700 border-slate-700 text-white'
-                : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-100'
-            } disabled:opacity-40`}
-            title="太字切替"
+          {/* Block B: 内容編集 */}
+          <div
+            className={`flex items-center gap-2 -mx-1 px-2 py-0.5 rounded-md transition-colors ${
+              hasContentDraft ? 'bg-amber-50 ring-1 ring-amber-200' : ''
+            }`}
           >
-            太字
-          </button>
+            <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wide">内容</span>
+            {hasContentDraft && (
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[10px] font-medium">
+                未保存
+              </span>
+            )}
+            <div className="flex flex-wrap items-center gap-1">
+              {!currentContact && (
+                <span className="px-1 text-xs text-gray-400">印刷対象を選択してください</span>
+              )}
+              {currentContact && selectedEditableFields.length === 0 && (
+                <span className="px-1 text-xs text-gray-400">編集項目を選択してください</span>
+              )}
+              {currentContact &&
+                selectedEditableFields.map((field) => (
+                  <label key={field} className="flex items-center gap-1 pl-1">
+                    <span className="text-[11px] text-gray-500">{EDITABLE_FIELD_LABELS[field]}</span>
+                    <input
+                      type="text"
+                      value={getEditableFieldValue(field)}
+                      onChange={(e) => updateEditableFieldValue(field, e.target.value)}
+                      disabled={contentSaving}
+                      className="h-8 min-w-[86px] rounded border border-gray-300 bg-white px-2 text-xs text-gray-700 disabled:opacity-40"
+                    />
+                  </label>
+                ))}
+            </div>
+          </div>
+
+          <div className="w-px bg-gray-200 self-stretch" aria-hidden="true" />
+
+          {/* Block C: 形状編集 */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wide">形状</span>
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-gray-500">サイズ</span>
+              <button
+                onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, -0.5))}
+                disabled={!selectedInspector}
+                className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
+                title="文字サイズを小さくする"
+              >
+                −
+              </button>
+              <input
+                type="number"
+                step={0.5}
+                value={selectedInspector ? selectedInspector.fontPt.toFixed(1) : ''}
+                onChange={(e) => updateSelectedFontFromInput(e.target.value)}
+                disabled={!selectedInspector}
+                className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
+                title="フォントサイズ (pt)"
+              />
+              <span className="text-xs text-gray-500">pt</span>
+              <button
+                onClick={() => updateSelectedField((tpl, id) => applyFontDelta(tpl, id, 0.5))}
+                disabled={!selectedInspector}
+                className="h-8 w-8 rounded border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-40"
+                title="文字サイズを大きくする"
+              >
+                ＋
+              </button>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-gray-500">X</span>
+              <input
+                type="number"
+                step={0.1}
+                value={selectedInspector ? selectedInspector.xMm.toFixed(1) : ''}
+                onChange={(e) => updateSelectedPositionFromInput('x', e.target.value)}
+                disabled={!selectedInspector}
+                className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
+                title="X 座標 (mm)"
+              />
+              <span className="text-xs text-gray-500">mm</span>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-gray-500">Y</span>
+              <input
+                type="number"
+                step={0.1}
+                value={selectedInspector ? selectedInspector.yMm.toFixed(1) : ''}
+                onChange={(e) => updateSelectedPositionFromInput('y', e.target.value)}
+                disabled={!selectedInspector}
+                className="h-8 w-20 rounded border border-gray-300 bg-white px-2 text-right text-xs text-gray-700 disabled:opacity-40"
+                title="Y 座標 (mm)"
+              />
+              <span className="text-xs text-gray-500">mm</span>
+            </div>
+
+            <div className="flex items-center rounded border border-gray-300 overflow-hidden">
+              <button
+                onClick={() => updateSelectedField((tpl, id) => applyFontFamily(tpl, id, 'serif'))}
+                disabled={!selectedBox}
+                className={`h-8 px-3 text-xs transition-colors ${
+                  selectedBox?.fontFamily === 'serif'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white text-gray-700 hover:bg-gray-100'
+                } disabled:opacity-40`}
+                title="明朝体"
+              >
+                明朝
+              </button>
+              <button
+                onClick={() =>
+                  updateSelectedField((tpl, id) => applyFontFamily(tpl, id, 'sans-serif'))
+                }
+                disabled={!selectedBox}
+                className={`h-8 px-3 text-xs border-l border-gray-300 transition-colors ${
+                  selectedBox?.fontFamily === 'sans-serif'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white text-gray-700 hover:bg-gray-100'
+                } disabled:opacity-40`}
+                title="ゴシック体"
+              >
+                ゴシック
+              </button>
+            </div>
+
+            <button
+              onClick={() => updateSelectedField((tpl, id) => applyBold(tpl, id, !selectedBox?.bold))}
+              disabled={!selectedBox}
+              className={`h-8 px-3 rounded border text-xs transition-colors ${
+                selectedBox?.bold
+                  ? 'bg-slate-700 border-slate-700 text-white'
+                  : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-100'
+              } disabled:opacity-40`}
+              title="太字切替"
+            >
+              太字
+            </button>
+          </div>
 
           <Popover
             triggerLabel="?"
@@ -692,7 +693,7 @@ export default function PreviewArea() {
       </div>
 
       {/* キャンバスエリア */}
-      <div className="flex-1 overflow-auto flex items-center justify-center p-6">
+      <div className="relative flex-1 overflow-auto flex items-center justify-center p-6">
         {mergedCurrentContact ? (
           // オフセット補正を CSS transform で可視化。
           // 背景ドラッグ → 印刷位置補正 / カラーハンドルドラッグ → 要素個別配置
@@ -735,6 +736,34 @@ export default function PreviewArea() {
           </div>
         ) : (
           <p className="text-gray-400 text-sm">住所録で印刷対象をONにしてください</p>
+        )}
+
+        {/* フローティング確定バー (内容ドラフト中のみ) */}
+        {(hasContentDraft || contentSaving) && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center z-20">
+            <div className="pointer-events-auto inline-flex items-center gap-3 px-4 py-2 rounded-full bg-white shadow-lg ring-1 ring-amber-200">
+              <span className="inline-flex items-center gap-1.5 text-xs text-amber-700">
+                <span aria-hidden="true">●</span>
+                内容に未保存の変更があります
+              </span>
+              <button
+                type="button"
+                onClick={cancelEditableContent}
+                disabled={contentSaving}
+                className="h-8 rounded-md border border-gray-300 bg-white px-3 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-40"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={() => void saveEditableContent()}
+                disabled={contentSaving}
+                className="h-8 rounded-md bg-blue-600 px-4 text-xs font-medium text-white shadow-sm hover:bg-blue-700 disabled:opacity-70"
+              >
+                {contentSaving ? '保存中...' : '確定'}
+              </button>
+            </div>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- issue #82 の Phase 3: ラベルプレビュー リボン2段目の編集インスペクタを情報設計レベルで再構成
- Phase 1 (#84) / Phase 2 (#85) に続く最後の主要 UI 改善

## 変更内容

### リボン2段目を3ブロックに視覚分割
- 「対象 / 内容 / 形状」の3ブロックを縦罫線 (`w-px bg-gray-200`) で区切り
- 各ブロックの先頭に小さな大文字ラベル (`uppercase tracking-wide`) を追加
- テキスト編集 (内容) と形状編集 (位置・フォント) の文脈混在を解消

### 内容ドラフト中の視覚フィードバック
- 内容ブロック全体に `bg-amber-50 ring-1 ring-amber-200` で着色
- 「未保存」バッジ (`amber-100` 背景) をブロック内に表示

### フローティング確定バー
- キャンセル / 確定ボタンをリボンから撤去
- キャンバス下部に角丸 pill 型のフローティングバーで再配置
- ドラフト中のみ表示 (`absolute inset-x-0 bottom-4 flex justify-center z-20`)
- 非ドラフト時はバー自体が消えるため、「保存済み」ボタンの常駐ノイズが消える

### 対象ピル ⇄ キャンバスハンドルの色連動
- 対象ピル選択時に pill 色のハロー (`box-shadow: 0 0 0 2px {color}55`) を追加
- LabelEditorOverlay の選択中ボックスに color-aware box-shadow + 濃度上げ + transition を追加
- 同じ色相が両方光ることで「いまどれを編集しているか」が一目でわかる

## Test plan
- [x] `node_modules/.bin/tsc --noEmit` 通過
- [x] `node_modules/.bin/vitest run` 全テスト pass (69/69)
- [x] リボン2段目が3ブロックで視覚的に分離されている
- [x] 対象ピル切替でキャンバス側ハンドルの色付きハローが連動する
- [x] 内容入力するとブロックが琥珀色になり「未保存」バッジが出る
- [x] フローティング確定バーが出る/消える、キャンセル・確定が機能する

Closes (主要部分): #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI改善**
  * 選択状態の視認性を向上（ボーダー、シャドウ効果を強化）
  * ツールバーレイアウトを3部構成に再構成
  * コンテンツ保存UIを新しいフローティングオーバーレイに移動
  * スムーズなトランジション効果を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->