### PR TITLE
[#87] ダッシュボード再構成 (Phase A)

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,82 +1,112 @@
-import { useEffect, useState } from 'react'
-import type { DashboardStats, PrintHistory } from '../types'
-import { GetDashboardStats, GetPrintHistory } from '../../wailsjs/go/main/App'
+import { useEffect, useMemo, useState } from 'react'
+import type { ContactYearStatus, DashboardStats, PrintHistory } from '../types'
+import {
+  GetContactYearStatuses,
+  GetDashboardStats,
+  GetPrintHistory,
+} from '../../wailsjs/go/main/App'
+
+interface AnnualSummary {
+  sent: number
+  received: number
+  mourning: number
+}
+
+const emptyAnnualSummary: AnnualSummary = { sent: 0, received: 0, mourning: 0 }
 
 export default function Dashboard({ onNavigate }: { onNavigate: (view: string) => void }) {
+  const currentYear = useMemo(() => new Date().getFullYear(), [])
+
   const [stats, setStats] = useState<DashboardStats>({ contactCount: 0, groupCount: 0 })
   const [history, setHistory] = useState<PrintHistory[]>([])
+  const [annual, setAnnual] = useState<AnnualSummary>(emptyAnnualSummary)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    Promise.all([GetDashboardStats(), GetPrintHistory(10)])
-      .then(([s, h]) => {
+    Promise.all([
+      GetDashboardStats(),
+      GetPrintHistory(10),
+      GetContactYearStatuses(currentYear),
+    ])
+      .then(([s, h, statuses]) => {
         setStats(s)
         setHistory(h ?? [])
+        setAnnual(aggregateAnnual(statuses ?? []))
       })
       .catch(console.error)
       .finally(() => setLoading(false))
-  }, [])
+  }, [currentYear])
 
   if (loading) {
-    return <div className="flex-1 flex items-center justify-center text-gray-400 text-sm">読み込み中...</div>
+    return (
+      <div className="flex-1 flex items-center justify-center text-gray-400 text-sm">
+        読み込み中...
+      </div>
+    )
   }
+
+  const heroState: HeroState =
+    stats.contactCount === 0
+      ? 'empty'
+      : history.length === 0
+        ? 'first-print'
+        : 'next-print'
 
   return (
     <div className="flex-1 overflow-y-auto p-6 space-y-6">
       <h2 className="text-xl font-semibold text-gray-800">ダッシュボード</h2>
 
-      {/* サマリーカード */}
-      <div className="grid grid-cols-2 gap-4">
-        <SummaryCard
-          label="連絡先"
-          value={stats.contactCount}
-          unit="件"
-          action="住所録を開く"
-          onClick={() => onNavigate('contacts')}
-        />
-        <SummaryCard
-          label="グループ"
-          value={stats.groupCount}
-          unit="件"
-          action="住所録を開く"
-          onClick={() => onNavigate('contacts')}
-        />
-      </div>
+      <NextStepHero state={heroState} onNavigate={onNavigate} />
 
-      {/* クイックアクション */}
       <section>
-        <h3 className="text-sm font-semibold text-gray-600 mb-2">クイックアクション</h3>
-        <div className="flex gap-3">
-          <QuickAction label="住所録を開く" onClick={() => onNavigate('contacts')} />
-          <QuickAction label="ラベル印刷" onClick={() => onNavigate('preview')} />
+        <h3 className="text-sm font-semibold text-gray-600 mb-2">サマリー</h3>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          <SummaryCard label="連絡先" value={stats.contactCount} unit="件" />
+          <SummaryCard label="グループ" value={stats.groupCount} unit="件" />
+          <SummaryCard
+            label={`${currentYear} 送付済`}
+            value={annual.sent}
+            unit="件"
+            accent="blue"
+          />
+          <SummaryCard
+            label={`${currentYear} 受取`}
+            value={annual.received}
+            unit="件"
+            accent="indigo"
+          />
+          <SummaryCard
+            label={`${currentYear} 喪中`}
+            value={annual.mourning}
+            unit="件"
+            accent="rose"
+          />
         </div>
       </section>
 
-      {/* 印刷履歴 */}
       <section>
         <h3 className="text-sm font-semibold text-gray-600 mb-2">最近の印刷履歴</h3>
         {history.length === 0 ? (
           <p className="text-sm text-gray-400">印刷履歴がありません。</p>
         ) : (
-          <div className="border border-gray-200 rounded-md overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 text-gray-500 text-xs">
-                <tr>
-                  <th className="text-left px-4 py-2 font-medium">印刷日時</th>
-                  <th className="text-right px-4 py-2 font-medium">枚数</th>
-                  <th className="text-center px-4 py-2 font-medium">QR</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {history.map((h) => (
-                  <tr key={h.id} className="bg-white">
-                    <td className="px-4 py-2 text-gray-700">{formatDate(h.printedAt)}</td>
-                    <td className="px-4 py-2 text-right text-gray-700">{h.contactCount} 件</td>
-                    <td className="px-4 py-2 text-center text-gray-400">{h.qrEnabled ? '✓' : '—'}</td>
-                  </tr>
+          <div className="space-y-2">
+            <LatestPrintRow history={history[0]} />
+            {history.length > 1 && (
+              <ul className="divide-y divide-gray-100 border border-gray-200 rounded-md bg-white">
+                {history.slice(1).map((h) => (
+                  <li
+                    key={h.id}
+                    className="flex items-center justify-between px-4 py-2 text-sm text-gray-700"
+                  >
+                    <span>{formatDate(h.printedAt)}</span>
+                    <span className="flex items-center gap-3 text-xs text-gray-500">
+                      <span>{h.contactCount} 件</span>
+                      <span>{h.qrEnabled ? 'QR ✓' : 'QR —'}</span>
+                    </span>
+                  </li>
                 ))}
-              </tbody>
-            </table>
+              </ul>
+            )}
           </div>
         )}
       </section>
@@ -84,44 +114,123 @@ export default function Dashboard({ onNavigate }: { onNavigate: (view: string) =
   )
 }
 
+type HeroState = 'empty' | 'first-print' | 'next-print'
+
+function NextStepHero({
+  state,
+  onNavigate,
+}: {
+  state: HeroState
+  onNavigate: (view: string) => void
+}) {
+  const config = {
+    empty: {
+      title: '最初の連絡先を追加しましょう',
+      description: 'CSV取込で一括登録するか、住所録から手動で追加できます。',
+      primary: { label: 'CSV取込で始める', view: 'contacts' },
+      secondary: { label: '住所録を開く', view: 'contacts' },
+    },
+    'first-print': {
+      title: 'ラベルを印刷してみましょう',
+      description: '住所録で印刷対象を選び、プレビュー画面から印刷できます。',
+      primary: { label: 'ラベル印刷へ', view: 'preview' },
+      secondary: { label: '住所録を開く', view: 'contacts' },
+    },
+    'next-print': {
+      title: '次のラベル印刷を始めましょう',
+      description: '前回の続きから印刷対象を選んで印刷できます。',
+      primary: { label: 'ラベル印刷へ', view: 'preview' },
+      secondary: { label: '住所録を開く', view: 'contacts' },
+    },
+  }[state]
+
+  return (
+    <section
+      aria-label="次の一歩"
+      className="rounded-lg border border-blue-100 bg-gradient-to-br from-blue-50 to-white p-5 shadow-sm"
+    >
+      <p className="text-base font-semibold text-blue-800">{config.title}</p>
+      <p className="mt-1 text-sm text-gray-600">{config.description}</p>
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onNavigate(config.primary.view)}
+          className="px-4 py-2 text-sm font-medium rounded-md bg-blue-600 text-white shadow-sm hover:bg-blue-700"
+        >
+          {config.primary.label}
+        </button>
+        <button
+          type="button"
+          onClick={() => onNavigate(config.secondary.view)}
+          className="px-3 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+        >
+          {config.secondary.label}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+const accentClassMap = {
+  default: { value: 'text-gray-800', label: 'text-gray-500' },
+  blue: { value: 'text-blue-700', label: 'text-blue-600' },
+  indigo: { value: 'text-indigo-700', label: 'text-indigo-600' },
+  rose: { value: 'text-rose-700', label: 'text-rose-600' },
+} as const
+
+type Accent = keyof typeof accentClassMap
+
 function SummaryCard({
   label,
   value,
   unit,
-  action,
-  onClick,
+  accent = 'default',
 }: {
   label: string
   value: number
   unit: string
-  action: string
-  onClick: () => void
+  accent?: Accent
 }) {
+  const colors = accentClassMap[accent]
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4">
-      <p className="text-xs text-gray-500 mb-1">{label}</p>
-      <p className="text-3xl font-bold text-gray-800">
+    <div className="bg-white border border-gray-200 rounded-lg px-4 py-3">
+      <p className={`text-[11px] font-medium uppercase tracking-wide ${colors.label}`}>{label}</p>
+      <p className={`mt-1 text-2xl font-bold ${colors.value}`}>
         {value}
         <span className="text-sm font-normal text-gray-500 ml-1">{unit}</span>
       </p>
-      <button
-        onClick={onClick}
-        className="mt-3 text-xs text-blue-600 hover:underline"
-      >
-        {action} →
-      </button>
     </div>
   )
 }
 
-function QuickAction({ label, onClick }: { label: string; onClick: () => void }) {
+function LatestPrintRow({ history }: { history: PrintHistory }) {
+  const relative = formatRelative(history.printedAt)
   return (
-    <button
-      onClick={onClick}
-      className="px-4 py-2 text-sm rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors"
-    >
-      {label}
-    </button>
+    <div className="rounded-md border border-blue-100 bg-blue-50/60 px-4 py-3 flex items-center justify-between">
+      <div>
+        <p className="text-[11px] font-medium uppercase tracking-wide text-blue-600">最終印刷</p>
+        <p className="mt-0.5 text-sm font-semibold text-gray-800">{formatDate(history.printedAt)}</p>
+        {relative && <p className="text-xs text-gray-500">{relative}</p>}
+      </div>
+      <div className="text-right">
+        <p className="text-2xl font-bold text-gray-800">
+          {history.contactCount}
+          <span className="text-sm font-normal text-gray-500 ml-1">件</span>
+        </p>
+        <p className="text-xs text-gray-500">{history.qrEnabled ? 'QR あり' : 'QR なし'}</p>
+      </div>
+    </div>
+  )
+}
+
+function aggregateAnnual(statuses: ContactYearStatus[]): AnnualSummary {
+  return statuses.reduce<AnnualSummary>(
+    (acc, s) => ({
+      sent: acc.sent + (s.sent ? 1 : 0),
+      received: acc.received + (s.received ? 1 : 0),
+      mourning: acc.mourning + (s.mourning ? 1 : 0),
+    }),
+    { ...emptyAnnualSummary },
   )
 }
 
@@ -138,4 +247,22 @@ function formatDate(iso: string): string {
   } catch {
     return iso
   }
+}
+
+function formatRelative(iso: string): string | null {
+  const d = new Date(iso)
+  const now = Date.now()
+  const diffMs = now - d.getTime()
+  if (!Number.isFinite(diffMs) || diffMs < 0) return null
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 1) return 'たった今'
+  if (minutes < 60) return `${minutes} 分前`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} 時間前`
+  const days = Math.floor(hours / 24)
+  if (days < 31) return `${days} 日前`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months} ヶ月前`
+  const years = Math.floor(days / 365)
+  return `${years} 年前`
 }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -21,8 +21,12 @@ export default function Dashboard({ onNavigate }: { onNavigate: (view: string) =
   const [history, setHistory] = useState<PrintHistory[]>([])
   const [annual, setAnnual] = useState<AnnualSummary>(emptyAnnualSummary)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
 
   useEffect(() => {
+    setLoading(true)
+    setError(null)
     Promise.all([
       GetDashboardStats(),
       GetPrintHistory(10),
@@ -33,14 +37,33 @@ export default function Dashboard({ onNavigate }: { onNavigate: (view: string) =
         setHistory(h ?? [])
         setAnnual(aggregateAnnual(statuses ?? []))
       })
-      .catch(console.error)
+      .catch((err) => {
+        console.error(err)
+        setError(err instanceof Error ? err.message : '読み込みに失敗しました。')
+      })
       .finally(() => setLoading(false))
-  }, [currentYear])
+  }, [currentYear, reloadKey])
 
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center text-gray-400 text-sm">
         読み込み中...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 text-sm">
+        <p className="text-red-600">データの読み込みに失敗しました。</p>
+        <p className="text-xs text-gray-500">{error}</p>
+        <button
+          type="button"
+          onClick={() => setReloadKey((k) => k + 1)}
+          className="px-4 py-2 text-sm rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+        >
+          再読み込み
+        </button>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- issue #87 の Phase A: ダッシュボード画面の情報設計を再構成
- 状態に応じた「次の一歩」CTA、年次サマリ、印刷履歴の見せ方を改善

## 変更内容

### 「次の一歩」hero カード (state-aware)
contactCount と history の有無から3状態を判定し、ユーザーに次にすべきアクションを提示：
- `empty` (連絡先 0 件): 「最初の連絡先を追加しましょう」+ CSV取込/住所録
- `first-print` (連絡先あり/印刷履歴なし): 「ラベルを印刷してみましょう」+ ラベル印刷/住所録
- `next-print` (履歴あり): 「次のラベル印刷を始めましょう」+ ラベル印刷/住所録
- グラデ背景 + primary/secondary 2 ボタンで視覚的に強調

### サマリカードの拡張
- 旧: 連絡先 / グループの 2 枚
- 新: + 当年の送付済 / 受取 / 喪中の計 5 枚 (grid-cols-5)
- `GetContactYearStatuses(currentYear)` を新規 fetch して集計
- accent カラー (blue/indigo/rose) で年次ステータスを識別

### 印刷履歴の再構成
- 旧: 10 件をテーブル表示
- 新: 最終印刷を青背景カードでハイライト + 残りを分割線リスト
- 「2 日前」「3 ヶ月前」など相対時刻も表示

## Test plan
- [x] `node_modules/.bin/tsc --noEmit` 通過
- [x] `node_modules/.bin/vitest run` 全テスト pass (69/69)
- [x] 連絡先 0 件で empty hero が表示される
- [x] 印刷履歴あり / なしで hero の文言・ボタンが切り替わる
- [x] 当年の年次サマリが集計される
- [x] 最終印刷ハイライトと履歴リストが分離して見える

Closes (部分対応): #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードのUIを再構成し、ヒーロー主導型フローと簡略化された要約・履歴レイアウトを導入しました

* **改善**
  * 年間統計情報の表示機能を追加しました
  * 印刷履歴の表示形式を改善し、最新のエントリーを強調表示するようにしました
  * 日付を相対時間形式（「3日前」など）で表示するようにしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->