### PR TITLE
[#87] 住所録の操作群を論理スコープ別に整理 (Phase B)

### DIFF
--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -781,114 +781,149 @@ export default function ContactList() {
         </button>
       </div>
 
-      {/* 選択/印刷対象コントロール */}
+      {/* セクション1: 件数表示 + 表示フィルタ */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 text-xs text-gray-500">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <span>
-            表示 {displayContacts.length} 件 / 印刷対象 {printTargetCount} 件
-            {selectedVisibleCount > 0 ? ` / 表示中選択 ${selectedVisibleCount} 件` : ''}
+            <span className="text-gray-700 font-medium">{displayContacts.length}</span> 件表示
           </span>
-          <span className="text-gray-300">|</span>
-          <label className="flex items-center gap-1">
-            年
-            <input
-              type="number"
-              min={minYear}
-              max={maxYear}
-              value={annualStatusYear}
-              onChange={(e) => {
-                const nextYear = Number(e.target.value)
-                if (Number.isInteger(nextYear) && nextYear >= 1900 && nextYear <= 3000) {
-                  setAnnualStatusYear(nextYear)
-                }
-              }}
-              className="w-20 rounded border border-gray-300 px-1 py-0.5 text-xs text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-500"
-            />
-          </label>
+          <span className="text-gray-300">/</span>
+          <span>
+            印刷対象 <span className="text-emerald-700 font-medium">{printTargetCount}</span> 件
+          </span>
+          {selectedVisibleCount > 0 && (
+            <>
+              <span className="text-gray-300">/</span>
+              <span>
+                選択 <span className="text-blue-700 font-medium">{selectedVisibleCount}</span> 件
+              </span>
+            </>
+          )}
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => {
-              setShowPrintTargetOnly((prev) => !prev)
-              clearSelection()
-              setEditingCell(null)
-            }}
-            className={`px-2 py-0.5 rounded border transition-colors ${
-              showPrintTargetOnly
-                ? 'bg-blue-50 border-blue-300 text-blue-700'
-                : 'border-gray-300 text-gray-600 hover:bg-gray-100'
-            }`}
-          >
-            {showPrintTargetOnly ? '全件表示' : '対象のみ表示'}
-          </button>
-        </div>
+        <button
+          onClick={() => {
+            setShowPrintTargetOnly((prev) => !prev)
+            clearSelection()
+            setEditingCell(null)
+          }}
+          className={`px-2 py-0.5 rounded border transition-colors ${
+            showPrintTargetOnly
+              ? 'bg-blue-50 border-blue-300 text-blue-700'
+              : 'border-gray-300 text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          {showPrintTargetOnly ? '全件表示' : '対象のみ表示'}
+        </button>
       </div>
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 text-xs text-gray-500 gap-2">
-        <div className="flex items-center gap-2">
+
+      {/* セクション2: 表示中スコープのアクション */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-1.5 border-b border-gray-100 text-xs">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-gray-500 shrink-0">
+          表示中 {displayContacts.length} 件
+        </span>
+        <div className="flex items-center gap-1">
           <button
             onClick={() => setSelectedIds(new Set(displayContacts.map((c) => c.id)))}
-            className="hover:text-blue-600 disabled:opacity-40"
+            className="px-1.5 py-0.5 rounded text-gray-600 hover:text-blue-600 hover:bg-gray-100 disabled:opacity-40 disabled:hover:bg-transparent"
             disabled={displayContacts.length === 0}
           >
-            表示中を全選択
+            全選択
           </button>
           <button
             onClick={clearSelection}
-            className="hover:text-blue-600 disabled:opacity-40"
+            className="px-1.5 py-0.5 rounded text-gray-600 hover:text-blue-600 hover:bg-gray-100 disabled:opacity-40 disabled:hover:bg-transparent"
             disabled={selectedIds.size === 0}
           >
             選択解除
           </button>
         </div>
-        <div className="flex items-center gap-2">
+        <span className="hidden sm:inline-block w-px h-4 bg-gray-200" aria-hidden="true" />
+        <div className="flex items-center gap-1">
+          <span className="text-gray-500">印刷対象:</span>
           <button
             onClick={() => void setPrintTargetForVisibleContacts(true)}
-            className="hover:text-blue-600 disabled:opacity-40"
+            className="px-1.5 py-0.5 rounded text-emerald-700 hover:bg-emerald-50 disabled:opacity-40 disabled:hover:bg-transparent"
             disabled={displayContacts.length === 0 || bulkUpdatingPrintTargets}
           >
-            表示中を対象ON
+            ON
           </button>
           <button
             onClick={() => void setPrintTargetForVisibleContacts(false)}
-            className="hover:text-blue-600 disabled:opacity-40"
+            className="px-1.5 py-0.5 rounded text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:hover:bg-transparent"
             disabled={displayContacts.length === 0 || bulkUpdatingPrintTargets}
           >
-            表示中を対象OFF
+            OFF
           </button>
         </div>
       </div>
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-100 text-xs text-gray-500 gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-gray-400">年次手動更新</span>
+
+      {/* セクション3: 選択中スコープの年次ステータスアクション */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-1.5 border-b border-gray-100 text-xs">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-gray-500 shrink-0">
+          選択中 {selectedVisibleCount} 件 を
+        </span>
+        <label className="flex items-center gap-1 text-gray-500">
+          <input
+            type="number"
+            min={minYear}
+            max={maxYear}
+            value={annualStatusYear}
+            onChange={(e) => {
+              const nextYear = Number(e.target.value)
+              if (Number.isInteger(nextYear) && nextYear >= 1900 && nextYear <= 3000) {
+                setAnnualStatusYear(nextYear)
+              }
+            }}
+            className="w-20 rounded border border-gray-300 px-1 py-0.5 text-xs text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            aria-label="年次ステータスの対象年"
+          />
+          <span>年に</span>
+        </label>
+        <div
+          className={`inline-flex rounded-md border border-gray-300 overflow-hidden divide-x divide-gray-300 ${
+            selectedVisibleContacts.length === 0 || annualStatusActionsDisabled ? 'opacity-50' : ''
+          }`}
+        >
           <button
             onClick={() => void setAnnualStatusForSelectedContacts({ sent: true })}
-            className="hover:text-blue-600 disabled:opacity-40"
+            className="px-2 py-0.5 text-blue-700 hover:bg-blue-50 disabled:cursor-not-allowed"
             disabled={selectedVisibleContacts.length === 0 || annualStatusActionsDisabled}
+            title="送付済にする"
           >
-            選択を送付済
+            送付済
           </button>
           <button
             onClick={() => void setAnnualStatusForSelectedContacts({ received: true })}
-            className="hover:text-blue-600 disabled:opacity-40"
+            className="px-2 py-0.5 text-indigo-700 hover:bg-indigo-50 disabled:cursor-not-allowed"
             disabled={selectedVisibleContacts.length === 0 || annualStatusActionsDisabled}
+            title="受取済にする"
           >
-            選択を受取済
+            受取
           </button>
           <button
             onClick={() => void setAnnualStatusForSelectedContacts({ mourning: true })}
-            className="hover:text-blue-600 disabled:opacity-40"
+            className="px-2 py-0.5 text-rose-700 hover:bg-rose-50 disabled:cursor-not-allowed"
             disabled={selectedVisibleContacts.length === 0 || annualStatusActionsDisabled}
+            title="喪中にする"
           >
-            選択を喪中
+            喪中
           </button>
           <button
-            onClick={() => void setAnnualStatusForSelectedContacts({ sent: false, received: false, mourning: false })}
-            className="hover:text-blue-600 disabled:opacity-40"
+            onClick={() =>
+              void setAnnualStatusForSelectedContacts({ sent: false, received: false, mourning: false })
+            }
+            className="px-2 py-0.5 text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed"
             disabled={selectedVisibleContacts.length === 0 || annualStatusActionsDisabled}
+            title="送付済・受取・喪中をすべてリセット"
           >
-            選択をクリア
+            リセット
           </button>
         </div>
+        {selectedVisibleContacts.length === 0 && (
+          <span className="text-[11px] text-gray-400">
+            行のチェックボックスで対象を選んでください
+          </span>
+        )}
       </div>
       {inlineSaveError && (
         <div className="px-3 py-2 text-xs text-red-600 bg-red-50 border-b border-red-100">


### PR DESCRIPTION
## Summary
- issue #87 の Phase B: 住所録テーブル上部の操作群（3 行 8+ ボタン）を論理スコープ別に再構成
- 「表示中」「選択中」のスコープ差を文言＆視覚で明示し、誤操作を防ぐ
- Phase A (#88) に続く情報設計改善

## 変更内容

### セクション1: 件数表示 + 表示フィルタ
- 件数を色分け表示: 印刷対象=緑、選択中=青
- 年input をセクション3 (年次ステータス) に移動して文脈を整理

### セクション2: 表示中スコープのアクション
- 先頭に「**表示中 N 件**」のスコープラベル
- 「全選択 / 選択解除」と「印刷対象: ON / OFF」を縦罫線で区切り、関係性を視覚化
- 「印刷対象 ON」を緑強調 (印刷対象列の色と統一)

### セクション3: 選択中スコープの年次ステータス
- 先頭に「**選択中 N 件 を {year} 年に**」のスコープラベル + 年input
- 年次ステータス 4 ボタンを ToggleGroup 風に集約 (rounded + divide-x):
  - 送付済 (blue)
  - 受取 (indigo)
  - 喪中 (rose)
  - リセット (gray)
- 各ボタン色は表中の年次ステータス checkbox と統一
- 選択 0 件時はグループを半透明化 + 「行のチェックボックスで対象を選んでください」のヒント

## Before / After (要点)
- Before: 8 ボタンが 3 行に密集、全部青リンク同形式、「表示中」と「選択」の差が文言からしか読めない
- After: 各セクション先頭にスコープ + 件数を明示、関連ボタンが視覚的に集約、操作の影響範囲が一目で分かる

## Test plan
- [x] `node_modules/.bin/tsc --noEmit` 通過
- [x] `node_modules/.bin/vitest run` 全テスト pass (69/69)
- [x] 「表示中 N 件」「選択中 N 件 を Y 年に」のスコープラベルが正しい件数を反映
- [x] 印刷対象件数が緑、選択件数が青で強調される
- [x] 年次ステータス 4 ボタンが連結ピル状で表示される
- [x] 選択 0 件のときに年次ステータスグループが薄くなり、ヒントが出る

Closes (部分対応): #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * コンタクトリストのコントロール領域を3つのセクションに再構成しました。件数表示とフィルター設定、選択・一括操作、ステータス更新機能がより論理的にグループ化され、ユーザーインターフェースの操作性と視認性が向上しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/araitatsuya-code/atena-print/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->