### PR TITLE
[#87] 印刷対象トグル ⇄ 行選択 の視覚分離 (Phase C)

### DIFF
--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -1200,8 +1200,8 @@ function PrintTargetSwitch({ on, disabled, onToggle }: PrintTargetSwitchProps) {
         e.stopPropagation()
         onToggle()
       }}
-      className={`relative inline-flex h-5 w-10 items-center rounded-full transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-        on ? 'bg-emerald-500' : 'bg-gray-300'
+      className={`relative inline-flex h-5 w-10 items-center rounded-full transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ${
+        on ? 'bg-emerald-500 focus-visible:ring-emerald-500' : 'bg-gray-300 focus-visible:ring-gray-400'
       }`}
       title={on ? '印刷対象です。クリックで除外' : '除外中。クリックで印刷対象に'}
     >

--- a/frontend/src/components/address/ContactList.tsx
+++ b/frontend/src/components/address/ContactList.tsx
@@ -950,7 +950,9 @@ export default function ContactList() {
           <table className="w-full min-w-[1220px] table-fixed border-separate border-spacing-0">
             <thead className="sticky top-0 z-10 bg-gray-50 text-xs text-gray-500">
               <tr>
-                <th className="w-10 px-2 py-2 border-b border-gray-200 text-left">選択</th>
+                <th className="w-10 px-2 py-2 border-b border-gray-200 text-center text-[11px] text-gray-400 font-normal">
+                  選択
+                </th>
                 <th
                   className="relative px-2 py-2 border-b border-gray-200 text-left font-medium select-none"
                   style={{
@@ -961,7 +963,12 @@ export default function ContactList() {
                   宛先
                   {renderResizeHandle(summaryColumnKey, minSummaryColumnWidth)}
                 </th>
-                <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">印刷対象</th>
+                <th className="w-20 px-2 py-2 border-b border-gray-200 text-left">
+                  <span className="inline-flex items-center gap-1">
+                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
+                    印刷
+                  </span>
+                </th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">{annualStatusYear}送付</th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">{annualStatusYear}受取</th>
                 <th className="w-16 px-2 py-2 border-b border-gray-200 text-left">{annualStatusYear}喪中</th>
@@ -1012,13 +1019,14 @@ export default function ContactList() {
                     }`}
                     onDoubleClick={() => setEditTarget(c)}
                   >
-                    <td className="px-2 py-1.5 border-b border-gray-100 align-top">
+                    <td className="px-2 py-1.5 border-b border-gray-100 align-top text-center">
                       <input
                         type="checkbox"
                         checked={selectedIds.has(c.id)}
                         onChange={() => toggleSelected(c.id)}
                         onClick={(e) => e.stopPropagation()}
                         className="mt-1 h-3.5 w-3.5 accent-blue-600"
+                        aria-label="行を選択"
                       />
                     </td>
                     <td className="px-2 py-1.5 border-b border-gray-100 align-top">
@@ -1033,13 +1041,10 @@ export default function ContactList() {
                       </div>
                     </td>
                     <td className="px-2 py-1.5 border-b border-gray-100 align-top">
-                      <input
-                        type="checkbox"
-                        checked={c.isPrintTarget}
+                      <PrintTargetSwitch
+                        on={c.isPrintTarget}
                         disabled={bulkUpdatingPrintTargets || updatingPrintTargetIds.has(c.id)}
-                        onChange={() => void togglePrintTarget(c)}
-                        onClick={(e) => e.stopPropagation()}
-                        className="mt-1 h-3.5 w-3.5 accent-emerald-600 disabled:opacity-40"
+                        onToggle={() => void togglePrintTarget(c)}
                       />
                     </td>
                     <td className="px-2 py-1.5 border-b border-gray-100 align-top">
@@ -1174,5 +1179,39 @@ export default function ContactList() {
         />
       )}
     </div>
+  )
+}
+
+interface PrintTargetSwitchProps {
+  on: boolean
+  disabled?: boolean
+  onToggle: () => void
+}
+
+function PrintTargetSwitch({ on, disabled, onToggle }: PrintTargetSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={on ? '印刷対象 ON (クリックでOFF)' : '印刷対象 OFF (クリックでON)'}
+      disabled={disabled}
+      onClick={(e) => {
+        e.stopPropagation()
+        onToggle()
+      }}
+      className={`relative inline-flex h-5 w-10 items-center rounded-full transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+        on ? 'bg-emerald-500' : 'bg-gray-300'
+      }`}
+      title={on ? '印刷対象です。クリックで除外' : '除外中。クリックで印刷対象に'}
+    >
+      <span className="sr-only">{on ? 'ON' : 'OFF'}</span>
+      <span
+        aria-hidden="true"
+        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+          on ? 'translate-x-[22px]' : 'translate-x-0.5'
+        }`}
+      />
+    </button>
   )
 }


### PR DESCRIPTION
## Summary
- issue #87 の Phase C: 隣接する 2 つの checkbox 列（行選択 / 印刷対象）が見た目で区別しづらい問題を解消
- Phase A (#88) / Phase B (#89) に続く情報設計改善の完結編

## 変更内容

### 印刷対象列 (列3): checkbox → トグルスイッチ
- 新規 \`PrintTargetSwitch\` コンポーネント (track + knob 構造)
  - ON 状態: \`bg-emerald-500\` + knob 右寄せ
  - OFF 状態: \`bg-gray-300\` + knob 左寄せ
- \`role=\"switch\"\` + \`aria-checked\` で a11y 対応
- title 属性で次の操作結果を説明（「クリックで除外」「クリックで印刷対象に」）
- 列幅 \`w-16\` → \`w-20\` でスイッチを収納

### 列ヘッダの差別化
- 行選択ヘッダ「選択」: 小さめの灰色テキスト + center 配置で控えめに
- 印刷対象ヘッダ「印刷」: 左に緑ドット (\`bg-emerald-500\`) を追加して列の意味を予告

### 行選択列 (列1)
- checkbox 本体は維持（青 = 選択スコープと統一）
- \`aria-label\` + \`text-center\` を追加して配置・a11y を改善

## Before / After
- Before: 列1（青 checkbox）と列3（緑 checkbox）が隣接して見た目が似ており、初見で混同しやすい
- After: 列1 は checkbox、列3 はトグルスイッチで **形状自体が異なる**。色と形の両方で機能を区別

## Test plan
- [x] \`node_modules/.bin/tsc --noEmit\` 通過
- [x] \`node_modules/.bin/vitest run\` 全テスト pass (69/69)
- [x] 行選択 (列1) と印刷対象 (列3) が形状で見分けられる
- [x] 印刷対象スイッチを ON / OFF すると track 色と knob 位置が連動する
- [x] ヘッダ「印刷」の左に緑ドットが表示される
- [x] 一括 ON/OFF (Phase B のセクション2) でスイッチが連動する
- [x] 選択行 (青背景) でもスイッチが視認できる

Closes: #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 連絡先テーブルの「印刷対象」操作を改善し、新しいスイッチ型コントロールを導入しました。

* **改善**
  * 列ヘッダーのレイアウトと表示を最適化しました。
  * アクセシビリティ機能を追加し、スクリーンリーダー対応を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/araitatsuya-code/atena-print/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->