### PR TITLE
[#91] 住所録 + プレビューを 1 view に統合 (Step 1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,6 @@ function App() {
     })),
   )
 
-  const showPreview = view === 'contacts' || view === 'preview'
   useEffect(() => {
     const clampContactPaneWidth = () => {
       const maxWidth = Math.max(minContactPaneWidth, window.innerWidth - 520)
@@ -93,7 +92,7 @@ function App() {
 
   const handleJumpToContact = (contactID: string) => {
     setShowPrintDialog(false)
-    setView('contacts')
+    setView('workspace')
     setCurrentGroupId('')
     setSearchQuery('')
     setSelectedIds(new Set([contactID]))
@@ -108,11 +107,8 @@ function App() {
         <NavButton active={view === 'dashboard'} onClick={() => setView('dashboard')}>
           ダッシュボード
         </NavButton>
-        <NavButton active={view === 'contacts'} onClick={() => setView('contacts')}>
-          住所録
-        </NavButton>
-        <NavButton active={view === 'preview'} onClick={() => setView('preview')}>
-          ラベルプレビュー
+        <NavButton active={view === 'workspace'} onClick={() => setView('workspace')}>
+          ラベル印刷
         </NavButton>
         <NavButton active={view === 'senders'} onClick={() => setView('senders')}>
           差出人管理
@@ -127,27 +123,25 @@ function App() {
         {view === 'dashboard' && (
           <Dashboard onNavigate={(v) => setView(v as View)} />
         )}
-        {view === 'contacts' && (
-          <div
-            className="relative border-r border-gray-200 bg-white flex flex-col h-full shrink-0"
-            style={{ width: contactPaneWidth, minWidth: minContactPaneWidth }}
-          >
-            <ContactList />
-            <button
-              type="button"
-              onPointerDown={startContactPaneResize}
-              className={`absolute right-0 top-0 z-30 h-full w-2 translate-x-1/2 cursor-col-resize touch-none ${
-                isResizingContactPane ? 'bg-blue-200/70' : 'hover:bg-blue-100/70'
-              }`}
-              aria-label="住所録パネルの幅を調整"
-              title="ドラッグして住所録パネルを広げる"
-            >
-              <span className="mx-auto block h-full w-px bg-gray-300" />
-            </button>
-          </div>
-        )}
-        {showPreview && (
+        {view === 'workspace' && (
           <>
+            <div
+              className="relative border-r border-gray-200 bg-white flex flex-col h-full shrink-0"
+              style={{ width: contactPaneWidth, minWidth: minContactPaneWidth }}
+            >
+              <ContactList />
+              <button
+                type="button"
+                onPointerDown={startContactPaneResize}
+                className={`absolute right-0 top-0 z-30 h-full w-2 translate-x-1/2 cursor-col-resize touch-none ${
+                  isResizingContactPane ? 'bg-blue-200/70' : 'hover:bg-blue-100/70'
+                }`}
+                aria-label="住所録パネルの幅を調整"
+                title="ドラッグして住所録パネルを広げる"
+              >
+                <span className="mx-auto block h-full w-px bg-gray-300" />
+              </button>
+            </div>
             <div className="flex-1 flex flex-col overflow-hidden min-w-0">
               {/* トップバー */}
               <div className="flex items-center gap-2 px-4 py-2 bg-white border-b border-gray-200 shrink-0">

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -150,20 +150,20 @@ function NextStepHero({
     empty: {
       title: '最初の連絡先を追加しましょう',
       description: 'CSV取込で一括登録するか、住所録から手動で追加できます。',
-      primary: { label: 'CSV取込で始める', view: 'contacts' },
-      secondary: { label: '住所録を開く', view: 'contacts' },
+      primary: { label: 'CSV取込で始める', view: 'workspace' },
+      secondary: { label: '住所録を開く', view: 'workspace' },
     },
     'first-print': {
       title: 'ラベルを印刷してみましょう',
       description: '住所録で印刷対象を選び、プレビュー画面から印刷できます。',
-      primary: { label: 'ラベル印刷へ', view: 'preview' },
-      secondary: { label: '住所録を開く', view: 'contacts' },
+      primary: { label: 'ラベル印刷へ', view: 'workspace' },
+      secondary: { label: '住所録を開く', view: 'workspace' },
     },
     'next-print': {
       title: '次のラベル印刷を始めましょう',
       description: '前回の続きから印刷対象を選んで印刷できます。',
-      primary: { label: 'ラベル印刷へ', view: 'preview' },
-      secondary: { label: '住所録を開く', view: 'contacts' },
+      primary: { label: 'ラベル印刷へ', view: 'workspace' },
+      secondary: { label: '住所録を開く', view: 'workspace' },
     },
   }[state]
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -259,4 +259,4 @@ export interface RestoreBackupResult {
   restartRequired: boolean
 }
 
-export type View = 'dashboard' | 'contacts' | 'preview' | 'senders' | 'settings'
+export type View = 'dashboard' | 'workspace' | 'senders' | 'settings'


### PR DESCRIPTION
## Summary
- issue #91 の Step 1: 業界標準（はがき作家・宛名職人・筆ぐるめ等）の「左：住所録 / 右：リアルタイムプレビュー」二分割レイアウトに揃え、view 横断の動線を排除
- 既存ロジック (`view === 'contacts' || view === 'preview'`) は既に並列表示対応済みだったので、view の統廃合のみで実現

## 変更内容

### View 型の統合 (`types.ts`)
- `'dashboard' | 'contacts' | 'preview' | 'senders' | 'settings'`
- → `'dashboard' | 'workspace' | 'senders' | 'settings'`

### 左サイドナビ (`App.tsx`)
- 5 項目 → 4 項目
- 「住所録」「ラベルプレビュー」を統合 → **「ラベル印刷」**
- workspace は常時 ContactList + PreviewArea の二分割
- `showPreview` フラグを撤廃

### 遷移先の統一
- `App.tsx#handleJumpToContact`: `setView('contacts')` → `setView('workspace')`
- `Dashboard.tsx`: hero card の view 遷移先を全て `'workspace'` に統一

## Before / After
- Before: 「住所録」→「ラベルプレビュー」と view を跨いで操作。並列表示はコード上できるが UI から伝わらない
- After: 「ラベル印刷」1 つで完結。リスト + プレビューが常時見えて操作の文脈が途切れない

## Test plan
- [x] `node_modules/.bin/tsc --noEmit` 通過
- [x] `node_modules/.bin/vitest run` 全テスト pass (69/69)
- [x] 左ナビが「ダッシュボード / ラベル印刷 / 差出人管理 / 設定」の 4 項目
- [x] 「ラベル印刷」で住所録 + プレビューが常時並列表示される
- [x] ダッシュボード hero ボタンから workspace に遷移できる
- [x] 印刷確認ダイアログの「住所録へジャンプ」が workspace を開く
- [x] リサイズハンドルで住所録の幅を変えられる

## 続編 (Step 2-4)
- Step 2: 上部ステッパー UI 導入
- Step 3: 差出人管理・設定の格下げ
- Step 4: 左サイドナビの最小化 or 撤廃

Closes (部分対応): #91