### PR TITLE
[#91] 差出人管理を設定タブに統合 (Step 3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,6 @@ import PreviewArea from './components/preview/PreviewArea'
 import DecorationSidebar from './components/decoration/DecorationSidebar'
 import LabelSettingsPanel from './components/label/LabelSettingsPanel'
 import PrintConfirmDialog from './components/PrintConfirmDialog'
-import SenderManager from './components/sender/SenderManager'
 import Dashboard from './components/Dashboard'
 import Settings from './components/Settings'
 import { useContactStore } from './stores/contactStore'
@@ -109,9 +108,6 @@ function App() {
         </NavButton>
         <NavButton active={view === 'workspace'} onClick={() => setView('workspace')}>
           ラベル印刷
-        </NavButton>
-        <NavButton active={view === 'senders'} onClick={() => setView('senders')}>
-          差出人管理
         </NavButton>
         <NavButton active={view === 'settings'} onClick={() => setView('settings')}>
           設定
@@ -219,11 +215,6 @@ function App() {
               </div>
             )}
           </>
-        )}
-        {view === 'senders' && (
-          <div className="flex-1 overflow-y-auto">
-            <SenderManager />
-          </div>
         )}
         {view === 'settings' && <Settings />}
       </main>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -10,6 +10,9 @@ import {
 } from '../../wailsjs/go/main/App'
 import { entity } from '../../wailsjs/go/models'
 import type { BackupGeneration, BackupSettings } from '../types'
+import SenderManager from './sender/SenderManager'
+
+type SettingsTab = 'sender' | 'data'
 
 const triggerLabelMap: Record<string, string> = {
   startup: '起動時',
@@ -19,6 +22,7 @@ const triggerLabelMap: Record<string, string> = {
 }
 
 export default function Settings() {
+  const [activeTab, setActiveTab] = useState<SettingsTab>('sender')
   const [version, setVersion] = useState('')
   const [exportMsg, setExportMsg] = useState('')
   const [importMsg, setImportMsg] = useState('')
@@ -144,9 +148,31 @@ export default function Settings() {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto p-6 space-y-8 max-w-4xl">
-      <h2 className="text-xl font-semibold text-gray-800">設定</h2>
-
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="px-6 pt-6 pb-0 bg-white border-b border-gray-200">
+        <h2 className="text-xl font-semibold text-gray-800 mb-3">設定</h2>
+        <div className="flex gap-1 -mb-px">
+          <SettingsTabButton
+            active={activeTab === 'sender'}
+            onClick={() => setActiveTab('sender')}
+          >
+            差出人
+          </SettingsTabButton>
+          <SettingsTabButton
+            active={activeTab === 'data'}
+            onClick={() => setActiveTab('data')}
+          >
+            データ・アプリ
+          </SettingsTabButton>
+        </div>
+      </div>
+      {activeTab === 'sender' && (
+        <div className="flex-1 overflow-y-auto">
+          <SenderManager />
+        </div>
+      )}
+      {activeTab === 'data' && (
+        <div className="flex-1 overflow-y-auto p-6 space-y-8 max-w-4xl">
       <section className="space-y-3">
         <h3 className="text-sm font-semibold text-gray-600 border-b border-gray-200 pb-2">データ管理</h3>
 
@@ -321,7 +347,34 @@ export default function Settings() {
           </p>
         </div>
       </section>
+        </div>
+      )}
     </div>
+  )
+}
+
+function SettingsTabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+        active
+          ? 'text-blue-700 border-blue-600'
+          : 'text-gray-500 border-transparent hover:text-gray-700 hover:bg-gray-50'
+      }`}
+    >
+      {children}
+    </button>
   )
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -259,4 +259,4 @@ export interface RestoreBackupResult {
   restartRequired: boolean
 }
 
-export type View = 'dashboard' | 'workspace' | 'senders' | 'settings'
+export type View = 'dashboard' | 'workspace' | 'settings'


### PR DESCRIPTION
## Summary
- issue #91 の Step 3: 業界標準ソフトに倣い、差出人マスタをメインフローから外して「設定」内に集約
- トップ階層のナビ項目を 4 → 3 に削減し、印刷フローの導線を明確化

## 変更内容

### 左サイドナビの簡素化
- 「差出人管理」項目を削除
- 4 項目 → 3 項目: **ダッシュボード / ラベル印刷 / 設定**

### 設定画面のタブ化 (Settings.tsx)
- 上部に 2 タブ:
  - **差出人** (デフォルト・初期表示)
  - **データ・アプリ** (既存のデータ管理 + バックアップ + バージョン情報)
- タブ切替で対応するコンテンツを表示
- `SettingsTabButton` helper をローカルに追加（PanelTab と同等のスタイル）

### View 型の更新
- `'dashboard' | 'workspace' | 'senders' | 'settings'` → `'dashboard' | 'workspace' | 'settings'`
- `App.tsx` から `view === 'senders'` レンダリング分岐と SenderManager 直接 import を削除（Settings 経由で利用）

## Before / After
- Before: 左ナビ4項目で「差出人管理」が並列。印刷フローと無関係なマスタ系がトップ階層を占めていた
- After: 左ナビ3項目に絞り、印刷フロー (ダッシュボード/ラベル印刷) と設定 (差出人/データ) で役割を明確に分離

## Test plan
- [x] `node_modules/.bin/tsc --noEmit` 通過
- [x] `node_modules/.bin/vitest run` 全テスト pass (69/69)
- [x] 左ナビが「ダッシュボード / ラベル印刷 / 設定」の 3 項目
- [x] 「設定」を開くと「差出人」タブが初期表示される
- [x] 「データ・アプリ」タブで既存のデータ管理 UI が表示される
- [x] タブ切替で内容が正しく切り替わる

## 続編 (Step 4)
- 左サイドナビの最小化 or 撤廃（ステッパーが導線として機能するため）

Closes (部分対応): #91