### PR TITLE
プレビュー画面のスクロール抜けと文字設定リボン折りたたみを追加

### DIFF
--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -171,6 +171,8 @@ export default function PreviewArea() {
 
   // グリッド表示フラグ (ローカル状態)
   const [showGrid, setShowGrid] = useState(false)
+  // 文字設定リボン (2段目) の表示フラグ
+  const [showFieldRibbon, setShowFieldRibbon] = useState(true)
   // フォント編集対象フィールド
   const [selectedFieldId, setSelectedFieldId] = useState<EditableFieldId | null>(null)
   // 内容編集ドラフト（選択中連絡先のみ）
@@ -485,8 +487,21 @@ export default function PreviewArea() {
               ＋
             </button>
           </div>
+          {/* 文字設定リボン折りたたみトグル */}
+          <button
+            onClick={() => setShowFieldRibbon((v) => !v)}
+            className="h-8 px-2 inline-flex items-center gap-1 text-xs rounded border border-gray-300 bg-white hover:bg-gray-100"
+            title={showFieldRibbon ? '文字設定を折りたたむ' : '文字設定を展開'}
+            aria-expanded={showFieldRibbon}
+          >
+            <span aria-hidden="true" className="text-[10px]">
+              {showFieldRibbon ? '▴' : '▾'}
+            </span>
+            文字設定
+          </button>
         </div>
 
+        {showFieldRibbon && (
         <div className="flex flex-wrap items-stretch gap-3 px-4 py-2 border-t border-gray-100 bg-gray-50">
           {/* Block A: 対象選択 */}
           <div className="flex items-center gap-2">
@@ -690,10 +705,12 @@ export default function PreviewArea() {
             <span className="text-[11px] text-red-600">{contentError}</span>
           )}
         </div>
+        )}
       </div>
 
       {/* キャンバスエリア */}
-      <div className="flex-1 overflow-auto flex items-center justify-center p-6">
+      <div className="flex-1 overflow-auto">
+        <div className="min-h-full flex items-center justify-center p-6">
         {mergedCurrentContact ? (
           // オフセット補正を CSS transform で可視化。
           // 背景ドラッグ → 印刷位置補正 / カラーハンドルドラッグ → 要素個別配置
@@ -737,6 +754,7 @@ export default function PreviewArea() {
         ) : (
           <p className="text-gray-400 text-sm">住所録で印刷対象をONにしてください</p>
         )}
+        </div>
       </div>
 
       {/* サムネイルナビゲーション (複数選択時) */}


### PR DESCRIPTION
## Summary
- プレビュー画面で報告された2つの問題に対応

## Fix 1: 縦長ラベル (はがき等) でのスクロール抜け
**症状**: ズームを上げて縦長ラベルがビューポートより大きくなったとき、上方向にスクロールできず上端が見切れる。

**原因**: \`overflow-auto\` コンテナの直下に \`flex items-center justify-center\` を使っていたため、コンテンツが overflow しても items-center が中央配置を維持し続けて上下端にスクロールできない「scroll prison」状態になっていた。

**修正**: \`overflow-auto\` の中に \`min-h-full flex items-center justify-center p-6\` のラッパーを追加。
- 小さいラベル: ラッパー高 = container 高となり中央寄せ（従来通り）
- 大きいラベル: ラッパーがコンテンツに従って伸び、上下にスクロール可能

## Fix 2: 文字設定リボン折りたたみ
**要望**: 「デザインのリボンを少し折りたたみたい」。文字設定 (対象/内容/形状) を常時表示せず、縦スペースを節約したい。

**実装**:
- ツールバー1段目右端に「▴ 文字設定」トグルボタンを追加
- クリックで \`showFieldRibbon\` state を切り替え (\`▴\`=展開中 / \`▾\`=折りたたみ)
- 折りたたむと 2 段目が消え、キャンバスエリアが広く使える
- \`aria-expanded\` 属性で a11y 対応

## Test plan
- [x] \`node_modules/.bin/tsc --noEmit\` 通過
- [x] \`node_modules/.bin/vitest run\` 全テスト pass (63/63)
- [x] 縦長ラベル + 高ズームで上方向にスクロールできる
- [x] 「文字設定」トグルで2段目が表示/非表示される
- [x] 折りたたみ中はキャンバスが広く使える