### PR TITLE
ラベルプリセットごとに専用テンプレートを定義し配置を整える

### DIFF
--- a/frontend/src/components/PrintConfirmDialog.tsx
+++ b/frontend/src/components/PrintConfirmDialog.tsx
@@ -13,7 +13,7 @@ import { useDecorationStore } from '../stores/decorationStore'
 import { useLabelStore } from '../stores/labelStore'
 import { usePreviewStore } from '../stores/previewStore'
 import { useSenderStore } from '../stores/senderStore'
-import { DEFAULT_TEMPLATE, DEFAULT_TEMPLATE_HORIZONTAL } from './preview/LabelCanvas'
+import { resolveTemplate } from '../lib/labelPresets'
 import { renderLabelSnapshotsToDataURLBatch } from '../lib/labelSnapshot'
 import { buildPreprintWarnings } from '../lib/printPreflight'
 import { useShallow } from 'zustand/shallow'
@@ -124,15 +124,12 @@ export default function PrintConfirmDialog({ onClose, onJumpToContact }: Props) 
   const paperLabel = `${layout.paperWidth}×${layout.paperHeight}mm (${layout.columns}列×${layout.rows}行)`
   const printableContactKey = printableContacts.map((c) => c.id).join(',')
 
-  function resolveTemplate() {
-    const defaultTpl = orientation === 'horizontal' ? DEFAULT_TEMPLATE_HORIZONTAL : DEFAULT_TEMPLATE
-    return selectedTemplate
-      ? { ...selectedTemplate, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
-      : { ...defaultTpl, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
+  function buildResolvedTemplate() {
+    return resolveTemplate(selectedTemplate, layout.labelWidth, layout.labelHeight, orientation)
   }
 
   function resolveTemplateAndContactIDs() {
-    const tpl = resolveTemplate()
+    const tpl = buildResolvedTemplate()
 
     let ids = printableContacts.map((c) => c.id)
     if (repeatFill && ids.length > 0 && ids.length < labelsPerPage) {
@@ -147,7 +144,7 @@ export default function PrintConfirmDialog({ onClose, onJumpToContact }: Props) 
     return { tpl, ids }
   }
 
-  const resolvedTemplate = useMemo(resolveTemplate, [orientation, selectedTemplate, layout])
+  const resolvedTemplate = useMemo(buildResolvedTemplate, [orientation, selectedTemplate, layout])
   const preprintWarnings = useMemo(
     () => buildPreprintWarnings(printableContacts, resolvedTemplate, unsupportedWarnings),
     [printableContacts, resolvedTemplate, unsupportedWarnings],

--- a/frontend/src/components/label/LabelSettingsPanel.tsx
+++ b/frontend/src/components/label/LabelSettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { useShallow } from 'zustand/shallow'
 import { useLabelStore } from '../../stores/labelStore'
+import { usePreviewStore } from '../../stores/previewStore'
 import type { LabelLayout } from '../../types'
 
 interface Preset {
@@ -98,6 +99,7 @@ export default function LabelSettingsPanel() {
       resetOffset: s.resetOffset,
     })),
   )
+  const setSelectedTemplate = usePreviewStore((s) => s.setSelectedTemplate)
 
   const currentPreset = matchPreset(layout)
 
@@ -106,6 +108,8 @@ export default function LabelSettingsPanel() {
     if (preset?.layout) {
       // オフセットは維持したままレイアウトを変更
       setLayout(preset.layout)
+      // ユーザーのカスタム配置をクリアし、新プリセットのフィールド配置を適用
+      setSelectedTemplate(null)
     }
   }
 

--- a/frontend/src/components/preview/LabelCanvas.tsx
+++ b/frontend/src/components/preview/LabelCanvas.tsx
@@ -1,76 +1,13 @@
 import { useEffect, useRef } from 'react'
 import type { Contact, Template } from '../../types'
 import { MM_TO_PX_AT_96_DPI, renderLabelTextLayer } from '../../lib/labelRenderer'
+import { DEFAULT_TEMPLATE, DEFAULT_TEMPLATE_HORIZONTAL } from '../../lib/labelPresets'
 
 /** 1mm あたりのピクセル数 (96 dpi 基準) */
 const MM_TO_PX = MM_TO_PX_AT_96_DPI // ≈ 3.78
 
-/**
- * デフォルトテンプレート: A4 12面ラベル (86.4×42.3mm) 縦書き
- * テンプレート選択 UI が実装されるまでのフォールバック用。
- */
-export const DEFAULT_TEMPLATE: Template = {
-  id: 'default-a4-12',
-  name: '標準 (A4 12面)',
-  orientation: 'vertical',
-  labelWidth: 86.4,
-  labelHeight: 42.3,
-  postalCode: {
-    x: 36,        // 〒マーク左端 (mm)
-    y: 4.5,       // 上端からの距離 (mm)
-    digitSpacing: 5.5,
-    fontSize: 10,
-  },
-  recipient: {
-    nameX: 79,    // 氏名カラム右端 (mm)
-    nameY: 8,     // 上端からの距離 (mm)
-    nameFont: 13,
-    addressX: 69, // 住所ブロック右端 (mm)
-    addressY: 8,  // 上端からの距離 (mm)
-    addressFont: 8.5,
-  },
-  sender: {
-    nameX: 16,    // 差出人氏名カラム右端 (mm)
-    nameY: 24,
-    nameFont: 6.5,
-    addressX: 8,  // 差出人住所ブロック右端 (mm)
-    addressY: 24,
-    addressFont: 5.5,
-  },
-}
-
-/**
- * デフォルトテンプレート: A4 12面ラベル (86.4×42.3mm) 横書き
- */
-export const DEFAULT_TEMPLATE_HORIZONTAL: Template = {
-  id: 'default-a4-12-h',
-  name: '標準 (A4 12面) 横書き',
-  orientation: 'horizontal',
-  labelWidth: 86.4,
-  labelHeight: 42.3,
-  postalCode: {
-    x: 5,
-    y: 3,
-    digitSpacing: 7,
-    fontSize: 9,
-  },
-  recipient: {
-    nameX: 5,
-    nameY: 13,
-    nameFont: 12,
-    addressX: 5,
-    addressY: 24,
-    addressFont: 8.5,
-  },
-  sender: {
-    nameX: 50,
-    nameY: 33,
-    nameFont: 6.5,
-    addressX: 50,
-    addressY: 37,
-    addressFont: 5.5,
-  },
-}
+// 後方互換のための再エクスポート (PreviewArea / PrintConfirmDialog などが参照)
+export { DEFAULT_TEMPLATE, DEFAULT_TEMPLATE_HORIZONTAL }
 
 interface LabelCanvasProps {
   contact: Contact

--- a/frontend/src/components/preview/PreviewArea.tsx
+++ b/frontend/src/components/preview/PreviewArea.tsx
@@ -4,7 +4,8 @@ import { SaveContact } from '../../../wailsjs/go/main/App'
 import { useContactStore } from '../../stores/contactStore'
 import { usePreviewStore } from '../../stores/previewStore'
 import { useDecorationStore } from '../../stores/decorationStore'
-import LabelCanvas, { DEFAULT_TEMPLATE, DEFAULT_TEMPLATE_HORIZONTAL } from './LabelCanvas'
+import LabelCanvas from './LabelCanvas'
+import { resolveTemplate } from '../../lib/labelPresets'
 import LabelEditorOverlay from './LabelEditorOverlay'
 import LabelGridOverlay from './LabelGridOverlay'
 import WatermarkLayer from './WatermarkLayer'
@@ -146,20 +147,26 @@ export default function PreviewArea() {
     }
   }, [selectedContacts.length, previewContactIndex, setPreviewContactIndex])
 
-  // 書字方向が変わったら保存済みテンプレートをリセット (縦書き用の座標を横書きに流用しない)
+  // 書字方向またはラベル寸法が変わったら、整合しなくなった保存済みテンプレートを破棄
   useEffect(() => {
-    if (selectedTemplate && selectedTemplate.orientation !== orientation) {
+    if (!selectedTemplate) return
+    const orientationMismatch = selectedTemplate.orientation !== orientation
+    const widthMismatch = Math.abs(selectedTemplate.labelWidth - layout.labelWidth) >= 0.5
+    const heightMismatch = Math.abs(selectedTemplate.labelHeight - layout.labelHeight) >= 0.5
+    if (orientationMismatch || widthMismatch || heightMismatch) {
       setSelectedTemplate(null)
     }
-  }, [orientation, selectedTemplate, setSelectedTemplate])
+  }, [orientation, layout.labelWidth, layout.labelHeight, selectedTemplate, setSelectedTemplate])
 
   const safeIndex = Math.max(0, Math.min(previewContactIndex, selectedContacts.length - 1))
   const currentContact: Contact | null = selectedContacts[safeIndex] ?? null
 
-  const defaultTpl = orientation === 'horizontal' ? DEFAULT_TEMPLATE_HORIZONTAL : DEFAULT_TEMPLATE
-  const template: Template = selectedTemplate
-    ? { ...selectedTemplate, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
-    : { ...defaultTpl, orientation, labelWidth: layout.labelWidth, labelHeight: layout.labelHeight }
+  const template: Template = resolveTemplate(
+    selectedTemplate,
+    layout.labelWidth,
+    layout.labelHeight,
+    orientation,
+  )
 
   const zoomIn = () => setZoom(clampZoom(Math.round((zoom + ZOOM_STEP) * 100) / 100))
   const zoomOut = () => setZoom(clampZoom(Math.round((zoom - ZOOM_STEP) * 100) / 100))

--- a/frontend/src/components/preview/labelEditorTemplate.ts
+++ b/frontend/src/components/preview/labelEditorTemplate.ts
@@ -33,6 +33,37 @@ export function buildEditableBoxes(tpl: Template): EditableBox[] {
   const labelWidth = tpl.labelWidth
   const boxes: EditableBox[] = []
 
+  // 宛名を先頭にして、印刷対象を選んだ後の自然な編集導線に合わせる
+  const recipient = tpl.recipient
+  if (isVertical) {
+    const nameWidth = (recipient.nameFont / 2.835) * 2.5
+    boxes.push({
+      id: 'recipientName',
+      label: '宛名',
+      visualXMm: recipient.nameX - nameWidth,
+      visualYMm: recipient.nameY,
+      widthMm: nameWidth,
+      heightMm: Math.max(5, labelHeight - recipient.nameY - 2),
+      fontPt: recipient.nameFont,
+      fontFamily: recipient.nameFontFamily ?? 'serif',
+      bold: recipient.nameBold ?? false,
+      color: '#10b981',
+    })
+  } else {
+    boxes.push({
+      id: 'recipientName',
+      label: '宛名',
+      visualXMm: recipient.nameX,
+      visualYMm: recipient.nameY,
+      widthMm: Math.max(10, labelWidth - recipient.nameX - 2),
+      heightMm: (recipient.nameFont / 2.835) * 1.8,
+      fontPt: recipient.nameFont,
+      fontFamily: recipient.nameFontFamily ?? 'serif',
+      bold: recipient.nameBold ?? false,
+      color: '#10b981',
+    })
+  }
+
   if (tpl.postalCode) {
     const postal = tpl.postalCode
     boxes.push({
@@ -49,21 +80,7 @@ export function buildEditableBoxes(tpl: Template): EditableBox[] {
     })
   }
 
-  const recipient = tpl.recipient
   if (isVertical) {
-    const nameWidth = (recipient.nameFont / 2.835) * 2.5
-    boxes.push({
-      id: 'recipientName',
-      label: '宛名',
-      visualXMm: recipient.nameX - nameWidth,
-      visualYMm: recipient.nameY,
-      widthMm: nameWidth,
-      heightMm: Math.max(5, labelHeight - recipient.nameY - 2),
-      fontPt: recipient.nameFont,
-      fontFamily: recipient.nameFontFamily ?? 'serif',
-      bold: recipient.nameBold ?? false,
-      color: '#10b981',
-    })
     const addressWidth = (recipient.addressFont / 2.835) * 2.5
     boxes.push({
       id: 'recipientAddr',
@@ -78,18 +95,6 @@ export function buildEditableBoxes(tpl: Template): EditableBox[] {
       color: '#f59e0b',
     })
   } else {
-    boxes.push({
-      id: 'recipientName',
-      label: '宛名',
-      visualXMm: recipient.nameX,
-      visualYMm: recipient.nameY,
-      widthMm: Math.max(10, labelWidth - recipient.nameX - 2),
-      heightMm: (recipient.nameFont / 2.835) * 1.8,
-      fontPt: recipient.nameFont,
-      fontFamily: recipient.nameFontFamily ?? 'serif',
-      bold: recipient.nameBold ?? false,
-      color: '#10b981',
-    })
     boxes.push({
       id: 'recipientAddr',
       label: '住所',

--- a/frontend/src/lib/labelPresets.ts
+++ b/frontend/src/lib/labelPresets.ts
@@ -1,0 +1,330 @@
+import type { Template } from '../types'
+
+/**
+ * ラベルサイズに合わせたフィールド配置のプリセット。
+ *
+ * 用紙プリセット (LabelSettingsPanel の PRESETS) と labelWidth × labelHeight で
+ * マッチさせ、対応する vertical / horizontal テンプレートを返す。
+ *
+ * マッチしない場合は A4 12面 のデフォルトにフォールバック。
+ */
+
+interface PresetTemplatePair {
+  /** プリセット識別用 (labelWidth × labelHeight で一致を判定) */
+  labelWidth: number
+  labelHeight: number
+  vertical: Template
+  horizontal: Template
+}
+
+/**
+ * A4 12面 (86.4×42.3mm) — 既存デフォルト
+ */
+const A4_12: PresetTemplatePair = {
+  labelWidth: 86.4,
+  labelHeight: 42.3,
+  vertical: {
+    id: 'preset-a4-12-v',
+    name: 'A4 12面 縦書き',
+    orientation: 'vertical',
+    labelWidth: 86.4,
+    labelHeight: 42.3,
+    postalCode: { x: 36, y: 4.5, digitSpacing: 5.5, fontSize: 10 },
+    recipient: {
+      nameX: 79,
+      nameY: 8,
+      nameFont: 13,
+      addressX: 69,
+      addressY: 8,
+      addressFont: 8.5,
+    },
+    sender: {
+      nameX: 16,
+      nameY: 24,
+      nameFont: 6.5,
+      addressX: 8,
+      addressY: 24,
+      addressFont: 5.5,
+    },
+  },
+  horizontal: {
+    id: 'preset-a4-12-h',
+    name: 'A4 12面 横書き',
+    orientation: 'horizontal',
+    labelWidth: 86.4,
+    labelHeight: 42.3,
+    // 上から: 郵便番号 → 住所 → 名前 (住所と名前は近接させてまとめる)
+    postalCode: { x: 5, y: 3, digitSpacing: 7, fontSize: 9 },
+    recipient: {
+      // 住所: 中段 (郵便番号の下)
+      addressX: 5,
+      addressY: 11,
+      addressFont: 8.5,
+      // 名前: 下段、大きく (住所の直下)
+      nameX: 5,
+      nameY: 22,
+      nameFont: 13,
+    },
+    sender: {
+      nameX: 50,
+      nameY: 33,
+      nameFont: 6.5,
+      addressX: 50,
+      addressY: 37,
+      addressFont: 5.5,
+    },
+  },
+}
+
+/**
+ * A4 10面 (86.4×50.8mm) — 12面 より縦に少し広い
+ */
+const A4_10: PresetTemplatePair = {
+  labelWidth: 86.4,
+  labelHeight: 50.8,
+  vertical: {
+    id: 'preset-a4-10-v',
+    name: 'A4 10面 縦書き',
+    orientation: 'vertical',
+    labelWidth: 86.4,
+    labelHeight: 50.8,
+    postalCode: { x: 36, y: 5, digitSpacing: 5.5, fontSize: 10 },
+    recipient: {
+      nameX: 79,
+      nameY: 10,
+      nameFont: 14,
+      addressX: 69,
+      addressY: 10,
+      addressFont: 9,
+    },
+    sender: {
+      nameX: 16,
+      nameY: 32,
+      nameFont: 7,
+      addressX: 8,
+      addressY: 32,
+      addressFont: 6,
+    },
+  },
+  horizontal: {
+    id: 'preset-a4-10-h',
+    name: 'A4 10面 横書き',
+    orientation: 'horizontal',
+    labelWidth: 86.4,
+    labelHeight: 50.8,
+    // 上から: 郵便番号 → 住所 → 名前
+    postalCode: { x: 5, y: 4, digitSpacing: 7, fontSize: 10 },
+    recipient: {
+      addressX: 5,
+      addressY: 13,
+      addressFont: 9,
+      nameX: 5,
+      nameY: 26,
+      nameFont: 15,
+    },
+    sender: {
+      nameX: 50,
+      nameY: 40,
+      nameFont: 7,
+      addressX: 50,
+      addressY: 44,
+      addressFont: 6,
+    },
+  },
+}
+
+/**
+ * A4 8面 (96.5×67.7mm) — 大きめラベル
+ * はがきに近いサイズなので、伝統的な縦書きはがき配置に揃える:
+ * - 郵便番号: 真ん中上
+ * - 受取人氏名: 中央, 大きい
+ * - 受取人住所: 右側 (右→左 の読み順)
+ * - 差出人: 左下
+ */
+const A4_8: PresetTemplatePair = {
+  labelWidth: 96.5,
+  labelHeight: 67.7,
+  vertical: {
+    id: 'preset-a4-8-v',
+    name: 'A4 8面 縦書き',
+    orientation: 'vertical',
+    labelWidth: 96.5,
+    labelHeight: 67.7,
+    // 〒 + 7 桁 (digitSpacing 6.5, 全幅 ≈ 54mm) を 96.5mm 幅で水平中央寄せ
+    postalCode: { x: 23, y: 6, digitSpacing: 6.5, fontSize: 12 },
+    recipient: {
+      // 氏名: ラベル幅 96.5 の中央 (column 幅 ≈ 16mm → rightEdge=56 で中央寄せ)
+      nameX: 56,
+      nameY: 14,
+      nameFont: 18,
+      // 住所: 右側 column rightEdge=88
+      addressX: 88,
+      addressY: 14,
+      addressFont: 12,
+    },
+    sender: {
+      // 差出人: 左下、控えめサイズ
+      nameX: 22,
+      nameY: 50,
+      nameFont: 8,
+      addressX: 12,
+      addressY: 50,
+      addressFont: 7,
+    },
+  },
+  horizontal: {
+    id: 'preset-a4-8-h',
+    name: 'A4 8面 横書き',
+    orientation: 'horizontal',
+    labelWidth: 96.5,
+    labelHeight: 67.7,
+    // 上から: 郵便番号 → 住所 → 名前
+    postalCode: { x: 7, y: 5, digitSpacing: 8, fontSize: 11 },
+    recipient: {
+      addressX: 7,
+      addressY: 16,
+      addressFont: 12,
+      nameX: 7,
+      nameY: 34,
+      nameFont: 18,
+    },
+    sender: {
+      nameX: 55,
+      nameY: 55,
+      nameFont: 8,
+      addressX: 55,
+      addressY: 60,
+      addressFont: 7,
+    },
+  },
+}
+
+/**
+ * はがき (100×148mm)
+ * - 縦書き: 伝統的レイアウト
+ *   - 郵便番号: 真ん中上 (7 桁を水平方向に中央寄せ)
+ *   - 受取人氏名: 中央, 大きい (focal point)
+ *   - 受取人住所: 右側 (縦書きの読み順 右→左 で最初に来る)
+ *   - 差出人: 左下 (控えめに)
+ * - 横書き: 郵便番号上, 宛名中央大きく, 差出人下
+ */
+const HAGAKI: PresetTemplatePair = {
+  labelWidth: 100,
+  labelHeight: 148,
+  vertical: {
+    id: 'preset-hagaki-v',
+    name: 'はがき 縦書き',
+    orientation: 'vertical',
+    labelWidth: 100,
+    labelHeight: 148,
+    // 〒 + 7 桁 (digitSpacing 8mm, 全幅 ≈ 62mm) を 100mm 幅で水平中央寄せ
+    postalCode: { x: 21, y: 12, digitSpacing: 8, fontSize: 13 },
+    recipient: {
+      // 氏名: ラベル幅 100 の中央に column rightEdge=60 (font 24pt の縦書きで column 幅 ≈21mm → 中央寄せ)
+      nameX: 60,
+      nameY: 35,
+      nameFont: 24,
+      // 住所: 右側 column rightEdge=88
+      addressX: 88,
+      addressY: 35,
+      addressFont: 14,
+    },
+    sender: {
+      // 差出人: 左下、控えめサイズ
+      nameX: 22,
+      nameY: 110,
+      nameFont: 10,
+      addressX: 10,
+      addressY: 110,
+      addressFont: 8,
+    },
+  },
+  horizontal: {
+    id: 'preset-hagaki-h',
+    name: 'はがき 横書き',
+    orientation: 'horizontal',
+    labelWidth: 100,
+    labelHeight: 148,
+    // 上から: 郵便番号 → 住所 → 名前
+    postalCode: { x: 10, y: 12, digitSpacing: 10, fontSize: 14 },
+    recipient: {
+      addressX: 10,
+      addressY: 32,
+      addressFont: 14,
+      nameX: 10,
+      nameY: 60,
+      nameFont: 26,
+    },
+    sender: {
+      nameX: 55,
+      nameY: 125,
+      nameFont: 10,
+      addressX: 55,
+      addressY: 132,
+      addressFont: 8,
+    },
+  },
+}
+
+const PRESET_TEMPLATES: PresetTemplatePair[] = [A4_12, A4_10, A4_8, HAGAKI]
+
+/** ラベル寸法が一致するプリセットを探す (許容差 ±0.5mm) */
+function matchPreset(labelWidth: number, labelHeight: number): PresetTemplatePair | null {
+  for (const preset of PRESET_TEMPLATES) {
+    if (
+      Math.abs(preset.labelWidth - labelWidth) < 0.5 &&
+      Math.abs(preset.labelHeight - labelHeight) < 0.5
+    ) {
+      return preset
+    }
+  }
+  return null
+}
+
+/**
+ * ラベル寸法・書字方向に合ったプリセットテンプレートを返す。
+ * 一致するプリセットが無い場合は A4 12面 のテンプレートを labelWidth/Height だけ
+ * 差し替えて返す (カスタムサイズでも壊れないように)。
+ */
+export function pickPresetTemplate(
+  labelWidth: number,
+  labelHeight: number,
+  orientation: 'vertical' | 'horizontal',
+): Template {
+  const matched = matchPreset(labelWidth, labelHeight)
+  if (matched) {
+    return orientation === 'horizontal' ? matched.horizontal : matched.vertical
+  }
+  const fallback = orientation === 'horizontal' ? A4_12.horizontal : A4_12.vertical
+  return { ...fallback, labelWidth, labelHeight }
+}
+
+/** A4 12面 デフォルトを既存名で再エクスポート (後方互換) */
+export const DEFAULT_TEMPLATE = A4_12.vertical
+export const DEFAULT_TEMPLATE_HORIZONTAL = A4_12.horizontal
+
+/**
+ * 現在のレイアウト・方向に整合するテンプレートを返す。
+ *
+ * - selectedTemplate が現在の方向 / 寸法と一致するならそれを採用
+ * - 不一致 (例: はがき横書きの編集を保存していたが今は縦書き、別サイズに変更) なら
+ *   プリセットのデフォルトに切り替える
+ *
+ * useEffect でクリアする方式だと「初回 render で古い template が一瞬出る」問題が
+ * 起きるため、render 時点で同期的に切り替える設計にする。
+ */
+export function resolveTemplate(
+  selectedTemplate: Template | null,
+  labelWidth: number,
+  labelHeight: number,
+  orientation: 'vertical' | 'horizontal',
+): Template {
+  const defaultTpl = pickPresetTemplate(labelWidth, labelHeight, orientation)
+  const isValidSelection =
+    selectedTemplate !== null &&
+    selectedTemplate.orientation === orientation &&
+    Math.abs(selectedTemplate.labelWidth - labelWidth) < 0.5 &&
+    Math.abs(selectedTemplate.labelHeight - labelHeight) < 0.5
+  const base = isValidSelection ? selectedTemplate : defaultTpl
+  return { ...base, orientation, labelWidth, labelHeight }
+}


### PR DESCRIPTION
## Summary
- 用紙プリセット (A4 12面 / A4 10面 / A4 8面 / はがき) ごとに **フィールド配置テンプレート** を用意し、用紙切替時にレイアウトも自動切替するように。
- 用紙だけ「はがき」に切り替えても文字配置が A4 12面のまま → 不自然 / はみ出し、という根本的な問題を解消。

## 変更内容

### 新規 \`frontend/src/lib/labelPresets.ts\`
- 4 プリセット × 縦/横 = **8 テンプレート** を定義
- \`pickPresetTemplate(width, height, orientation)\` でラベル寸法から該当テンプレートを取得
- \`resolveTemplate(selectedTemplate, width, height, orientation)\` で「selectedTemplate が現在の寸法+方向と整合するか」を render 時に同期判定 (useEffect 任せだと「初回 render で古いレイアウトが一瞬出る」問題が起きる)

### 縦書きレイアウト
- **はがき**: 伝統的な縦書き配置 (郵便番号: 真ん中上、名前: 中央 24pt、住所: 右側、差出人: 左下)
- **A4 8面**: 同じくはがき寄りの中央配置 (大きめラベル向け)
- **A4 10面 / A4 12面**: 既存の A4 mailing label 慣習 (送信者左 / 受取人右) を維持

### 横書きレイアウト (要望に対応)
ユーザー要望: 「上から郵便番号 → 住所 → 名前 の順、住所と名前は近接」
- 旧: 郵便番号 → 名前 → 住所
- 新: 郵便番号 → 住所 → 名前 (住所と名前を block 化)
- 各プリセットで Y 位置を再配置し、名前フォントを若干強調

### 不具合修正
- **はがき・横→縦の戻りが反映されない問題**: \`useEffect\` でクリアする方式の race を解消。\`resolveTemplate\` で render 時に整合性チェックして同期切替
- **A4 8面 縦書きの列重なり**: nameX/addressX を再設計しカラム重なりを解消
- **はがき postal の overflow**: 旧 x=44 だと 7 桁が右端をはみ出していた (100mm 幅で 104mm まで達する)。x=21 で中央寄せ

### 編集ピル順序の変更
ユーザー要望: 「印刷対象を選んでから宛名選択」
- \`buildEditableBoxes\` の順序を **宛名 → 郵便番号 → 住所** に変更
- リボン Block A の先頭ピル = 宛名 になり、デフォルト選択も宛名に

### プリセット切替時のクリア
- \`LabelSettingsPanel\` の preset 切替で \`setSelectedTemplate(null)\` を呼び、ユーザーのカスタム配置をリセット → 新プリセットの defaults を適用

## Test plan
- [x] \`node_modules/.bin/tsc --noEmit\` 通過
- [x] \`node_modules/.bin/vitest run\` 全テスト pass (63/63)
- [ ] はがきプリセット → 縦書きで郵便番号が中央上、名前が中央大きく、住所が右側
- [ ] はがき → 横書きにして縦書きに戻すと縦書きレイアウトに戻る
- [ ] 横書きでは「郵便番号 → 住所 → 名前」の縦並び
- [ ] A4 8面で列重なりがない
- [ ] リボン Block A の先頭ピルが「宛名」

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * プリセット切替時にカスタムレイアウト設定をリセットするよう改善しました。

* **Refactor**
  * ラベルテンプレート解決ロジックを統一化し、プリセット管理を一元化しました。
  * テンプレート選択条件にラベル寸法の比較を追加し、保存済みテンプレートの再利用判定を拡張しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/araitatsuya-code/atena-print/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->